### PR TITLE
Fix nginx ssl directive is deprecated

### DIFF
--- a/install/debian/10/templates/web/nginx/force-https-legacy.stpl
+++ b/install/debian/10/templates/web/nginx/force-https-legacy.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%proxy_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
-    # ssl         on;
+
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/debian/10/templates/web/nginx/force-https-public.stpl
+++ b/install/debian/10/templates/web/nginx/force-https-public.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%proxy_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
-    # ssl         on;
+
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/debian/10/templates/web/nginx/force-https-webmail-phpmyadmin.stpl
+++ b/install/debian/10/templates/web/nginx/force-https-webmail-phpmyadmin.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%proxy_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
-    # ssl         on;
+
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/debian/10/templates/web/nginx/force-https.stpl
+++ b/install/debian/10/templates/web/nginx/force-https.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%proxy_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
-    # ssl         on;
+
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/debian/10/templates/web/nginx/hosting-legacy.stpl
+++ b/install/debian/10/templates/web/nginx/hosting-legacy.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%proxy_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
-    # ssl         on;
+    
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/debian/10/templates/web/nginx/hosting-public.stpl
+++ b/install/debian/10/templates/web/nginx/hosting-public.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%proxy_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
-    # ssl         on;
+
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/debian/10/templates/web/nginx/hosting-webmail-phpmyadmin.stpl
+++ b/install/debian/10/templates/web/nginx/hosting-webmail-phpmyadmin.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%proxy_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
-    # ssl         on;
+
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/debian/10/templates/web/nginx/hosting.stpl
+++ b/install/debian/10/templates/web/nginx/hosting.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%proxy_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
-    # ssl         on;
+
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/debian/10/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port% ssl;
+    listen      %ip%:%web_ssl_port% ssl https;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;

--- a/install/debian/10/templates/web/nginx/php-fpm/cms_made_simple.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/cms_made_simple.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port% ssl https;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;

--- a/install/debian/10/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/codeigniter2.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/codeigniter2.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port% ssl;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;

--- a/install/debian/10/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/codeigniter3.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/codeigniter3.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port% ssl;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;

--- a/install/debian/10/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -1,13 +1,12 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
-
-    ssl         on;
+    
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/datalife_engine.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/datalife_engine.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port% ssl;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;

--- a/install/debian/10/templates/web/nginx/php-fpm/default.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/default.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/default.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/default.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port% ssl;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;

--- a/install/debian/10/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/dokuwiki.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/dokuwiki.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port% ssl;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;

--- a/install/debian/10/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/drupal6.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/drupal6.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/drupal6.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port% ssl;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;

--- a/install/debian/10/templates/web/nginx/php-fpm/drupal7.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/drupal7.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/drupal8.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/drupal8.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/joomla.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/joomla.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/laravel.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/laravel.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%/public;
     index       index.php index.html index.htm;
@@ -7,8 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     

--- a/install/debian/10/templates/web/nginx/php-fpm/magento.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/magento.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
 
     root        %sdocroot%/pub;
@@ -9,7 +9,6 @@ server {
     error_page  404 403 = /errors/404.php;
     add_header  "X-UA-Compatible" "IE=Edge";
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/modx.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/modx.stpl
@@ -1,13 +1,12 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
     access_log  /var/log/nginx/domains/%domain%.log combined;
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
-
-    ssl         on;
+    
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 #   if you need to rewrite www to non-www uncomment bellow

--- a/install/debian/10/templates/web/nginx/php-fpm/moodle.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/moodle.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/no-php.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/no-php.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/odoo.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/odoo.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/opencart.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/opencart.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/owncloud.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/owncloud.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/owncloud.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port% ssl;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;

--- a/install/debian/10/templates/web/nginx/php-fpm/piwik.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/piwik.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%/public;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/pyrocms.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/pyrocms.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port% ssl;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%/public;
     index       index.php index.html index.htm;

--- a/install/debian/10/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/wordpress.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/wordpress.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/wordpress.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port% ssl;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;

--- a/install/debian/10/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/wordpress2.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/wordpress2.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port% ssl;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %sdocroot%;
     index       index.php index.html index.htm;

--- a/install/debian/10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port%;
+    listen      %ip%:%web_ssl_port% ssl;
     server_name %domain_idn% %alias_idn%;
     root        %docroot%;
     index       index.php index.html index.htm;
@@ -7,7 +7,6 @@ server {
     access_log  /var/log/nginx/domains/%domain%.bytes bytes;
     error_log   /var/log/nginx/domains/%domain%.error.log error;
 
-    ssl         on;
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
 

--- a/install/debian/10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
+++ b/install/debian/10/templates/web/nginx/php-fpm/wordpress2_rewrite.stpl
@@ -1,5 +1,5 @@
 server {
-    listen      %ip%:%web_ssl_port% ssl;
+    listen      %ip%:%web_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
     root        %docroot%;
     index       index.php index.html index.htm;

--- a/install/debian/10/templates/web/nginx/private-force-https.stpl
+++ b/install/debian/10/templates/web/nginx/private-force-https.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%proxy_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
-    # ssl         on;
+
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;

--- a/install/debian/10/templates/web/nginx/private-hosting.stpl
+++ b/install/debian/10/templates/web/nginx/private-hosting.stpl
@@ -1,7 +1,7 @@
 server {
     listen      %ip%:%proxy_ssl_port% ssl http2;
     server_name %domain_idn% %alias_idn%;
-    # ssl         on;
+
     ssl_certificate      %ssl_pem%;
     ssl_certificate_key  %ssl_key%;
     error_log  /var/log/%web_system%/domains/%domain%.error.log error;


### PR DESCRIPTION
Fix for nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead
- Removed unnecessary  "# ssl on;"  comments
- Reformatted listen to new format "listen ... ssl http2" and enable http/2 
