### PR TITLE
Change if to is (fix for #105)

### DIFF
--- a/bin/v-add-web-domain
+++ b/bin/v-add-web-domain
@@ -49,7 +49,7 @@ is_package_full 'WEB_DOMAINS' 'WEB_ALIASES'
 is_domain_new 'web' "$domain,$aliases"
 is_dir_symlink $HOMEDIR/$user/web
 if_dir_exists $HOMEDIR/$user/web/$domain
-if_dir_symlink $HOMEDIR/$user/web/$domain
+is_dir_symlink $HOMEDIR/$user/web/$domain
 if [ ! -z "$ip" ]; then
     is_ip_valid "$ip" "$user"
 else


### PR DESCRIPTION
main.sh defines the command as is_dir_symlink, not if_dir_symlink.

https://github.com/myvesta/vesta/blob/13d58ff390fb6613be6626811183064cf71603ca/func/main.sh#L296