### PR TITLE
Regex string threaded literally instead as regex

### DIFF
--- a/func/main.sh
+++ b/func/main.sh
@@ -551,7 +551,7 @@ is_user_format_valid() {
 is_domain_format_valid() {
     object_name=${2-domain}
     exclude="[!|@|#|$|^|&|*|(|)|+|=|{|}|:|,|<|>|?|_|/|\|\"|'|;|%|\`| ]"
-    if [[ $1 =~ $exclude ]] || [[ $1 =~ ^[0-9]+$ ]] || [[ $1 =~ "\.\." ]] || [[ $1 =~ "$(printf '\t')" ]]; then
+    if [[ $1 =~ $exclude ]] || [[ $1 =~ ^[0-9]+$ ]] || [[ $1 =~ \.\. ]] || [[ $1 =~ $(printf '\t') ]]; then
         check_result $E_INVALID "invalid $object_name format :: $1"
     fi
 }


### PR DESCRIPTION
During shellcheck of Hestia source code I noticed the following error matching the line:
^----^ SC2076: Don't quote right-hand side of =~, it'll match literally rather than as a regex.
                                                                                      ^--------------^ SC2076: Don't quote right-hand side of =~, it'll match literally rather 
Proof of concept:
root@dev:~# v-add-web-domain jaap jaap..nu 
Error: nginx restart failed
root@dev:~# v-add-web-domain jaap jaap..nu 
Error: invalid domain format :: jaap..nu