### PR TITLE
avoid out-of-memory serving large logfiles

### DIFF
--- a/web/download/web-log/index.php
+++ b/web/download/web-log/index.php
@@ -10,8 +10,6 @@ if ((!isset($_GET['token'])) || ($_SESSION['token'] != $_GET['token'])) {
     exit();
 }
 
-$v_domain = $_GET['domain'];
-$v_domain = escapeshellarg($_GET['domain']);
 if ($_GET['type'] == 'access') $type = 'access';
 if ($_GET['type'] == 'error') $type = 'error';
 
@@ -21,7 +19,7 @@ header("Content-Disposition: attachment; filename=".$_GET['domain'].".".$type."-
 header("Content-Type: application/octet-stream; "); 
 header("Content-Transfer-Encoding: binary");
 
-$v_domain = escapeshellarg($_GET['domain']);
+$v_domain = $_GET['domain'];
 if ($_GET['type'] == 'access') $type = 'access';
 if ($_GET['type'] == 'error') $type = 'error';
 

--- a/web/download/web-log/index.php
+++ b/web/download/web-log/index.php
@@ -26,14 +26,24 @@ if ($_GET['type'] == 'access') $type = 'access';
 if ($_GET['type'] == 'error') $type = 'error';
 
 
-
 $cmd = implode(" ", array(
     escapeshellarg(VESTA_CMD . "v-list-web-domain-" . $type . "log"),
     escapeshellarg($user),
     escapeshellarg($v_domain),
     "5000",
 ));
-passthru($cmd, $return_var);
+
+if(is_callable("passthru")){
+    passthru($cmd, $return_var);
+} else{
+    // passthru is disabled, workaround it by writing the output to a file then reading the file. 
+    // this is slower than passthru, but avoids running out of RAM...
+    $passthru_is_disabled_workaround_handle = tmpfile();
+    $passthru_is_disabled_workaround_file = stream_get_meta_data($passthru_is_disabled_workaround_handle)['uri'];
+    exec ($cmd . " > " . escapeshellarg($passthru_is_disabled_workaround_file), $output, $return_var);
+    readfile($passthru_is_disabled_workaround_file);
+    fclose($passthru_is_disabled_workaround_handle); // fclose(tmpfile()) automatically deletes the file, unlink is not required :)
+}
 if ($return_var != 0) {
     $errstr = "Internal server error: command returned non-zero: {$return_var}: {$cmd}";
     echo $errstr;

--- a/web/download/web-log/index.php
+++ b/web/download/web-log/index.php
@@ -25,11 +25,18 @@ $v_domain = escapeshellarg($_GET['domain']);
 if ($_GET['type'] == 'access') $type = 'access';
 if ($_GET['type'] == 'error') $type = 'error';
 
-exec (VESTA_CMD."v-list-web-domain-".$type."log $user ".$v_domain." 5000", $output, $return_var);
-if ($return_var == 0 ) {
-    foreach($output as $file) {
-        echo $file . "\n";
-    }
+
+
+$cmd = implode(" ", array(
+    escapeshellarg(HESTIA_CMD . "v-list-web-domain-" . $type . "log"),
+    escapeshellarg($user),
+    escapeshellarg($v_domain),
+    "5000",
+));
+passthru($cmd, $return_var);
+if ($return_var != 0) {
+    $errstr = "Internal server error: command returned non-zero: {$return_var}: {$cmd}";
+    echo $errstr;
+    throw new Exception($errstr); // make sure it ends up in an errorlog somewhere
 }
 
-?>

--- a/web/download/web-log/index.php
+++ b/web/download/web-log/index.php
@@ -28,7 +28,7 @@ if ($_GET['type'] == 'error') $type = 'error';
 
 
 $cmd = implode(" ", array(
-    escapeshellarg(HESTIA_CMD . "v-list-web-domain-" . $type . "log"),
+    escapeshellarg(VESTA_CMD . "v-list-web-domain-" . $type . "log"),
     escapeshellarg($user),
     escapeshellarg($v_domain),
     "5000",

--- a/web/download/web-log/index.php
+++ b/web/download/web-log/index.php
@@ -25,7 +25,7 @@ if ($_GET['type'] == 'error') $type = 'error';
 
 
 $cmd = implode(" ", array(
-    escapeshellarg(VESTA_CMD . "v-list-web-domain-" . $type . "log"),
+    VESTA_CMD . "v-list-web-domain-" . $type . "log",
     escapeshellarg($user),
     escapeshellarg($v_domain),
     "5000",


### PR DESCRIPTION
large logfiles previously resulted in out-of-memory errors, see https://github.com/hestiacp/hestiacp/issues/2736

hestacp PR: https://github.com/hestiacp/hestiacp/pull/2741

and no, removing the php end tag was not an accident, it was intentional. end tags, ideally, should only be used when they're absolutely required, because they can easily introduce bugs like printing a newline after the end tag.