### PR TITLE
Fix db.sh + rebuild.sh mailadres & subject

### DIFF
--- a/func/db.sh
+++ b/func/db.sh
@@ -29,6 +29,9 @@ mysql_connect() {
     mysql --defaults-file=$mycnf -e 'SELECT VERSION()' > $mysql_out 2>&1
     if [ '0' -ne "$?" ]; then
         if [ "$notify" != 'no' ]; then
+            subj="Error: Connection to $HOST failed"
+            email=$($BIN/v-get-user-value admin CONTACT)
+
             echo -e "Can't connect to MySQL $HOST\n$(cat $mysql_out)" |\
                 $SENDMAIL -s "$subj" $email
         fi
@@ -59,6 +62,9 @@ mysql_dump() {
     if [ '0' -ne "$?" ]; then
         rm -rf $tmpdir
         if [ "$notify" != 'no' ]; then
+            subj="Error: dump $database failed"
+            email=$($BIN/v-get-user-value admin CONTACT)
+
             echo -e "Can't dump database $database\n$(cat $err)" |\
                 $SENDMAIL -s "$subj" $email
         fi
@@ -82,6 +88,9 @@ psql_connect() {
     psql -h $HOST -U $USER -c "SELECT VERSION()" > /dev/null 2>/tmp/e.psql
     if [ '0' -ne "$?" ]; then
         if [ "$notify" != 'no' ]; then
+            subj="Error: Connection to $HOST failed"
+            email=$($BIN/v-get-user-value admin CONTACT)
+
             echo -e "Can't connect to PostgreSQL $HOST\n$(cat /tmp/e.psql)" |\
                 $SENDMAIL -s "$subj" $email
         fi
@@ -103,6 +112,9 @@ psql_dump() {
     if [ '0' -ne "$?" ]; then
         rm -rf $tmpdir
         if [ "$notify" != 'no' ]; then
+            subj="Error: dump $database failed"
+            email=$($BIN/v-get-user-value admin CONTACT)
+            
             echo -e "Can't dump database $database\n$(cat /tmp/e.psql)" |\
                 $SENDMAIL -s "$subj" $email
         fi

--- a/func/rebuild.sh
+++ b/func/rebuild.sh
@@ -610,6 +610,9 @@ rebuild_pgsql_database() {
     if [ -z $HOST ] || [ -z $USER ] || [ -z $PASSWORD ] || [ -z $TPL ]; then
         echo "Error: postgresql config parsing failed"
         if [ ! -z "$SENDMAIL" ]; then
+            subj="Error: postgresql config parsing failed"
+            email=$($BIN/v-get-user-value admin CONTACT)
+
             echo "Can't parse PostgreSQL config" | $SENDMAIL -s "$subj" $email
         fi
         log_event "$E_PARSING" "$ARGUMENTS"
@@ -621,6 +624,9 @@ rebuild_pgsql_database() {
     if [ '0' -ne "$?" ];  then
         echo "Error: Connection failed"
         if [ ! -z "$SENDMAIL" ]; then
+            subj="Error: Connection failed"
+            email=$($BIN/v-get-user-value admin CONTACT)
+
             echo "Database connection to PostgreSQL host $HOST failed" |\
                 $SENDMAIL -s "$subj" $email
         fi


### PR DESCRIPTION
Hello,

I had changed my root mysql password and then locked the account. I took a look at my catch-all mail address a few days later, and saw the mails below:

![afbeelding](https://github.com/myvesta/vesta/assets/76551334/82b79484-3219-40d2-9bb9-4ae592121c77)

I went to investigate, and had apparently forgotten to update my new password in vesta.conf (And don't lock my root account, oops). I just fixed the mail in /db.sh immediately as well. Now the mail does get sent to the admin email address + subject is now filled in. 

After an additional check, I was able to fix this for rebuild.sh as well. 

Not much experience with this, so if there is anything I can do better please let me know. 
