### PR TITLE
disable root login phpmyadmin

### DIFF
--- a/install/vst-install-debian.sh
+++ b/install/vst-install-debian.sh
@@ -1364,6 +1364,9 @@ if [ "$mysql" = 'yes' ] || [ "$mysql8" = 'yes' ]; then
       bash /root/phpmyadmin/pma.sh
       blowfish=$(gen_pass)
       echo "\$cfg['blowfish_secret'] = '$blowfish';" >> /etc/phpmyadmin/config.inc.php
+
+      # disable root login
+      echo "\$cfg['Servers'][\$i]['AllowRoot'] = FALSE;" >> /etc/phpmyadmin/config.inc.php
   fi
   if [ "$release" -gt 10 ]; then
       echo "=== Configure phpMyAdmin (Debian11 custom part)"
@@ -1381,6 +1384,9 @@ if [ "$mysql" = 'yes' ] || [ "$mysql8" = 'yes' ]; then
       bash /root/phpmyadmin/pma.sh
       blowfish=$(gen_pass)
       echo "\$cfg['blowfish_secret'] = '$blowfish';" >> /etc/phpmyadmin/config.inc.php
+
+      # disable root login
+      echo "\$cfg['Servers'][\$i]['AllowRoot'] = FALSE;" >> /etc/phpmyadmin/config.inc.php
   fi
 fi
 


### PR DESCRIPTION
As seen in my previous pull request, I wanted to lock the root mysql user, but of course that is not possible. Then I thought; why is root login not disabled as default in phpmyadmin. 

Therefore, here is a suggestion to disallow default "root" login in phpmyadmin. That seems safer to me personally, and should they still want to use a root account they can better create a new account with a unique name. 

I have tested it, and I have not encountered any errors with this modification. Feedback is always welcome.