### PR TITLE
Update add_mail_acc.js

### DIFF
--- a/web/js/pages/add_mail_acc.js
+++ b/web/js/pages/add_mail_acc.js
@@ -154,7 +154,7 @@ $(document).ready(function() {
                 $('#td_smtp_encryption').html('STARTTLS');
                 break;
             case 'ssl':
-                $('#td_imap_port').html('993');
+                $('#td_imap_port').html('995');
                 $('#td_imap_encryption').html('SSL / TLS');
                 $('#td_smtp_port').html('465');
                 $('#td_smtp_encryption').html('SSL / TLS');


### PR DESCRIPTION
I noticed that the ssl option in the mail configuration UI sets the IMAP port to 993, which is correct for IMAP over SSL/TLS (IMAPS). However, when verifying an email account in Gmail’s "Check mail from other accounts" feature, port 993 didn’t work because Gmail requires POP3 over SSL/TLS on port 995 (POP3S). This caused confusion since the UI labels this as "IMAP Port," but users may need POP3 for certain setups like Gmail.

