### PR TITLE
Update exim4.conf.template

### DIFF
--- a/install/debian/12/exim/exim4.conf.template
+++ b/install/debian/12/exim/exim4.conf.template
@@ -4,262 +4,363 @@
 #                                                                    #
 ######################################################################
 
+# Placeholder for primary_hostname (to be set dynamically during installation)
+# primary_hostname = mail.domain.com
+
 #SPAMASSASSIN = yes
 #SPAM_SCORE = 50
-#CLAMD =  yes
+#CLAMD = yes
 
-disable_ipv6=true
-add_environment=<; PATH=/bin:/usr/bin
-keep_environment=
+# Disable IPv6 for Exim to avoid connectivity issues on systems without IPv6
+disable_ipv6 = true
+
+# Define environment variables for Exim subprocesses
+add_environment = <; PATH=/bin:/usr/bin
+keep_environment =
+
+# Disable SMTPUTF8 advertisement (not needed for most setups)
 smtputf8_advertise_hosts =
 
+# Load SRS secret for Sender Rewriting Scheme (used for email forwarding)
 SRS_SECRET = ${readfile{/etc/exim4/srs.conf}}
 
-#local_interfaces =  0.0.0.0
+# Uncomment to bind Exim to specific interfaces (e.g., 0.0.0.0 for all interfaces)
+#local_interfaces = 0.0.0.0
+
+# Uncomment to set smtp_active_hostname dynamically based on interface address
 #smtp_active_hostname = ${lookup{$interface_address}lsearch{/etc/exim4/virtual/helo_data}{$value}}
+
+# Uncomment to customize the SMTP banner with the hostname and timestamp
 #smtp_banner = "$smtp_active_hostname ESMTP $tod_full"
 
+# Define domains handled by this server (local_domains are those in /etc/exim4/domains/)
 domainlist local_domains = dsearch;/etc/exim4/domains/
+
+# Define domains to relay to (also in /etc/exim4/domains/)
 domainlist relay_to_domains = dsearch;/etc/exim4/domains/
+
+# Define trusted relay hosts (e.g., localhost)
 hostlist relay_from_hosts = 127.0.0.1
+
+# Define whitelisted IPs (loaded from /etc/exim4/white-blocks.conf)
 hostlist whitelist = net-iplsearch;/etc/exim4/white-blocks.conf
+
+# Define blacklisted IPs (loaded from /etc/exim4/spam-blocks.conf)
 hostlist spammers = net-iplsearch;/etc/exim4/spam-blocks.conf
+
+# Disable local sender verification (useful for virtual domains)
 no_local_from_check
+
+# Allow untrusted senders to set the sender address
 untrusted_set_sender = *
+
+# Define ACLs for various SMTP stages
 acl_smtp_connect = acl_check_spammers
 acl_smtp_mail = acl_check_mail
 acl_smtp_rcpt = acl_check_rcpt
 acl_smtp_data = acl_check_data
 acl_smtp_mime = acl_check_mime
 
+# Define recipient and email sending limits per email/hosting account
 LIMIT_PER_EMAIL_ACCOUNT_MAX_RECIPIENTS = 15
 LIMIT_PER_HOSTING_ACCOUNT_MAX_RECIPIENTS = 5
 LIMIT_PER_EMAIL_ACCOUNT_MAX_SENT_EMAILS_PER_HOUR = 40
 LIMIT_PER_HOSTING_ACCOUNT_MAX_SENT_EMAILS_PER_HOUR = 40
 
+# Set maximum recipients per email and reject if exceeded
 recipients_max = 150
 recipients_max_reject = true
 
+# Uncomment to enable detailed logging for SMTP connections
 # log_selector = +smtp_connection
+
+# Limit concurrent SMTP connections
 smtp_accept_max = 50
 smtp_accept_max_per_host = 4
 
+# Configure SpamAssassin if enabled
 .ifdef SPAMASSASSIN
 spamd_address = 127.0.0.1 783
 .endif
 
+# Configure ClamAV if enabled
 .ifdef CLAMD
 av_scanner = clamd: /var/run/clamav/clamd.ctl
 .endif
 
+# Advertise TLS for all hosts
 tls_advertise_hosts = *
+
+# Specify paths to TLS certificate and private key
 tls_certificate = /usr/local/vesta/ssl/certificate.crt
 tls_privatekey = /usr/local/vesta/ssl/certificate.key
 
+# Define SMTP ports (25 for standard SMTP, 465 for SMTPS, 587 for submission, 2525 as alternative)
 daemon_smtp_ports = 25 : 465 : 587 : 2525
+
+# Define ports that use TLS-on-connect (SMTPS)
 tls_on_connect_ports = 465
+
+# Prevent Exim from running as root
 never_users = root
+
+# Perform host lookup for all incoming connections
 host_lookup = *
+
+# Disable RFC 1413 ident queries (not commonly used)
 rfc1413_hosts = *
 rfc1413_query_timeout = 0s
+
+# Ignore bounce errors after 2 days
 ignore_bounce_errors_after = 2d
+
+# Remove frozen messages after 7 days
 timeout_frozen_after = 7d
 
+# Configure DKIM settings for outgoing emails
 DKIM_DOMAIN = ${lc:${domain:$h_from:}}
 DKIM_FILE = /etc/exim4/domains/${lookup{${lc:${domain:$h_from:}}}dsearch{/etc/exim4/domains/}}/dkim.pem
 DKIM_PRIVATE_KEY = ${if exists{DKIM_FILE}{DKIM_FILE}{0}}
-
-
 
 ######################################################################
 #                       ACL CONFIGURATION                            #
 #         Specifies access control lists for incoming SMTP mail      #
 ######################################################################
 
+# Define ACL for non-SMTP (local) submissions
 acl_not_smtp = acl_not_smtp
 
 begin acl
 
+# ACL for non-SMTP (local) submissions
 acl_not_smtp:
+  # Deny if the number of recipients exceeds the per-hosting-account limit
   deny message = Too many recipients, limit is $acl_c_max_recipients recipients
-  set acl_c_max_recipients=${lookup{$authenticated_id}lsearch{/etc/exim4/limit_per_hosting_account_max_recipients}{$value}{LIMIT_PER_HOSTING_ACCOUNT_MAX_RECIPIENTS}}
-  condition = ${if >{$rcpt_count}{$acl_c_max_recipients}}
+       set acl_c_max_recipients=${lookup{$authenticated_id}lsearch{/etc/exim4/limit_per_hosting_account_max_recipients}{$value}{LIMIT_PER_HOSTING_ACCOUNT_MAX_RECIPIENTS}}
+       condition = ${if >{$rcpt_count}{$acl_c_max_recipients}}
 
+  # Deny if the hosting account exceeds the hourly email sending limit
   deny message = Hosting account is sending too much emails [limitlog]: deny / account / $authenticated_id / $sender_rate / $sender_rate_period [limit=$acl_c_limit_per_hour]
-  set acl_c_limit_per_hour=${lookup{$authenticated_id}lsearch{/etc/exim4/limit_per_hosting_account_max_sent_emails_per_hour}{$value}{LIMIT_PER_HOSTING_ACCOUNT_MAX_SENT_EMAILS_PER_HOUR}}
-  ratelimit = $acl_c_limit_per_hour / 1h / $authenticated_id
+       set acl_c_limit_per_hour=${lookup{$authenticated_id}lsearch{/etc/exim4/limit_per_hosting_account_max_sent_emails_per_hour}{$value}{LIMIT_PER_HOSTING_ACCOUNT_MAX_SENT_EMAILS_PER_HOUR}}
+       ratelimit = $acl_c_limit_per_hour / 1h / $authenticated_id
 
+  # Log the sender rate for the hosting account
   warn ratelimit = 0 / 1h / strict / $authenticated_id
-  set acl_c_limit_per_hour=${lookup{$authenticated_id}lsearch{/etc/exim4/limit_per_hosting_account_max_sent_emails_per_hour}{$value}{LIMIT_PER_HOSTING_ACCOUNT_MAX_SENT_EMAILS_PER_HOUR}}
-  log_message = Sender rate [limitlog]: log / account / $authenticated_id / $sender_rate / $sender_rate_period [limit=$acl_c_limit_per_hour]
+       set acl_c_limit_per_hour=${lookup{$authenticated_id}lsearch{/etc/exim4/limit_per_hosting_account_max_sent_emails_per_hour}{$value}{LIMIT_PER_HOSTING_ACCOUNT_MAX_SENT_EMAILS_PER_HOUR}}
+       log_message = Sender rate [limitlog]: log / account / $authenticated_id / $sender_rate / $sender_rate_period [limit=$acl_c_limit_per_hour]
 
-  warn    set acl_m3    = yes
+  # Set a flag for later use in the ACL
+  warn set acl_m3 = yes
 
+  # Accept the message
   accept
 
+# ACL to check for spammers on SMTP connection
 acl_check_spammers:
-  accept  hosts         = +whitelist
+  # Accept connections from whitelisted IPs
+  accept hosts = +whitelist
 
-  drop    message       = Your host in blacklist on this server.
-          log_message   = Host in blacklist
-          hosts         = +spammers
+  # Drop connections from blacklisted IPs
+  drop message = Your host in blacklist on this server.
+       log_message = Host in blacklist
+       hosts = +spammers
 
+  # Accept all other connections
   accept
 
-
+# ACL to validate the MAIL FROM command
 acl_check_mail:
-  deny    condition     = ${if eq{$sender_helo_name}{}}
-          message       = HELO required before MAIL
+  # Deny if the HELO name is empty
+  deny condition = ${if eq{$sender_helo_name}{}}
+       message = HELO required before MAIL
 
-  drop    !authenticated = *
-          message       = Helo name contains a ip address (HELO was $sender_helo_name) and not is valid
-          condition     = ${if match{$sender_helo_name}{\N((\d{1,3}[.-]\d{1,3}[.-]\d{1,3}[.-]\d{1,3})|([0-9a-f]{8})|([0-9A-F]{8}))\N}{yes}{no}}
-          condition     = ${if match {${lookup dnsdb{>: defer_never,ptr=$sender_host_address}}\}{$sender_helo_name}{no}{yes}}
-          delay         = 45s
+  # Drop unauthenticated connections where HELO contains an IP address and doesn't match reverse DNS
+  drop !authenticated = *
+       message = Helo name contains a ip address (HELO was $sender_helo_name) and not is valid
+       condition = ${if match{$sender_helo_name}{\N((\d{1,3}[.-]\d{1,3}[.-]\d{1,3}[.-]\d{1,3})|([0-9a-f]{8})|([0-9A-F]{8}))\N}{yes}{no}}
+       condition = ${if match {${lookup dnsdb{>: defer_never,ptr=$sender_host_address}}\}{$sender_helo_name}{no}{yes}}
+       delay = 45s
 
-  drop    !authenticated = *
-          condition     = ${if isip{$sender_helo_name}}
-          message       = Access denied - Invalid HELO name (See RFC2821 4.1.3)
+  # Drop unauthenticated connections where HELO is an IP address
+  drop !authenticated = *
+       condition = ${if isip{$sender_helo_name}}
+       message = Access denied - Invalid HELO name (See RFC2821 4.1.3)
 
-  drop    !authenticated = *
-          condition     = ${if eq{[$interface_address]}{$sender_helo_name}}
-          message       = $interface_address is _my_ address
+  # Drop unauthenticated connections where HELO matches the server's own IP
+  drop !authenticated = *
+       condition = ${if eq{[$interface_address]}{$sender_helo_name}}
+       message = $interface_address is _my_ address
 
+  # Accept the MAIL FROM command
   accept
 
-
+# ACL to validate the RCPT TO command
 acl_check_rcpt:
-  accept  hosts         = :
+  # Accept local connections (no authentication needed)
+  accept hosts = :
 
+  # Allow deliveries to local domains on port 25 without authentication
+  accept domains = +local_domains
+         verify = recipient
+
+  # Block unauthenticated sends on port 25 for NON-local domains (prevent relay)
+  deny message = SMTP auth required for port 25
+       condition = ${if eq{$interface_port}{25}}
+       !authenticated = *
+       hosts = !+relay_from_hosts
+       domains = !+local_domains
+
+  # Deny if the number of recipients exceeds the per-email-account limit
   deny message = Too many recipients, limit is $acl_c_max_recipients recipients
-  set acl_c_max_recipients=${lookup{$authenticated_id}lsearch{/etc/exim4/limit_per_email_account_max_recipients}{$value}{LIMIT_PER_EMAIL_ACCOUNT_MAX_RECIPIENTS}}
-  condition = ${if >{$rcpt_count}{$acl_c_max_recipients}}
+       set acl_c_max_recipients=${lookup{$authenticated_id}lsearch{/etc/exim4/limit_per_email_account_max_recipients}{$value}{LIMIT_PER_EMAIL_ACCOUNT_MAX_RECIPIENTS}}
+       condition = ${if >{$rcpt_count}{$acl_c_max_recipients}}
 
+  # Deny if the email account exceeds the hourly email sending limit
   deny message = Email account is sending too much emails [limitlog]: deny / email / $authenticated_id / $sender_rate / $sender_rate_period [limit=$acl_c_limit_per_hour]
-  set acl_c_limit_per_hour=${lookup{$authenticated_id}lsearch{/etc/exim4/limit_per_email_account_max_sent_emails_per_hour}{$value}{LIMIT_PER_EMAIL_ACCOUNT_MAX_SENT_EMAILS_PER_HOUR}}
-  ratelimit = $acl_c_limit_per_hour / 1h / $authenticated_id
+       set acl_c_limit_per_hour=${lookup{$authenticated_id}lsearch{/etc/exim4/limit_per_email_account_max_sent_emails_per_hour}{$value}{LIMIT_PER_EMAIL_ACCOUNT_MAX_SENT_EMAILS_PER_HOUR}}
+       ratelimit = $acl_c_limit_per_hour / 1h / $authenticated_id
 
+  # Log the sender rate for the email account
   warn ratelimit = 0 / 1h / strict / $authenticated_id
-  set acl_c_limit_per_hour=${lookup{$authenticated_id}lsearch{/etc/exim4/limit_per_email_account_max_sent_emails_per_hour}{$value}{LIMIT_PER_EMAIL_ACCOUNT_MAX_SENT_EMAILS_PER_HOUR}}
-  log_message = Sender rate [limitlog]: log / email / $authenticated_id / $sender_rate / $sender_rate_period [limit=$acl_c_limit_per_hour]
+       set acl_c_limit_per_hour=${lookup{$authenticated_id}lsearch{/etc/exim4/limit_per_email_account_max_sent_emails_per_hour}{$value}{LIMIT_PER_EMAIL_ACCOUNT_MAX_SENT_EMAILS_PER_HOUR}}
+       log_message = Sender rate [limitlog]: log / email / $authenticated_id / $sender_rate / $sender_rate_period [limit=$acl_c_limit_per_hour]
 
-  warn    set acl_m3    = no
-  
-  warn    !authenticated = *
-          hosts          = !+relay_from_hosts
-          condition     = ${if eq{${lookup{$domain}dsearch{/etc/exim4/domains/}}}{}{false}{true}}
-          condition     = ${lookup{$local_part@$domain}lsearch{/etc/exim4/domains/${lookup{$domain}dsearch{/etc/exim4/domains/}}/aliases}{true}{false}}
-          set acl_m3    = yes
+  # Reset the flag used earlier
+  warn set acl_m3 = no
 
-  deny    message       = Restricted characters in address
-          domains       = +local_domains
-          local_parts   = ^[.] : ^.*[@%!/|]
+  # Set flag for alias deliveries to local domains (unauthenticated)
+  warn !authenticated = *
+       hosts = !+relay_from_hosts
+       condition = ${if eq{${lookup{$domain}dsearch{/etc/exim4/domains/}}}{}{false}{true}}
+       condition = ${lookup{$local_part@$domain}lsearch{/etc/exim4/domains/${lookup{$domain}dsearch{/etc/exim4/domains/}}/aliases}{true}{false}}
+       set acl_m3 = yes
 
-  deny    message       = Restricted characters in address
-          domains       = !+local_domains
-          local_parts   = ^[./|] : ^.*[@%!] : ^.*/\\.\\./
+  # Deny addresses with restricted characters in local domains
+  deny message = Restricted characters in address
+       domains = +local_domains
+       local_parts = ^[.] : ^.*[@%!/|]
 
-  require verify        = sender
+  # Deny addresses with restricted characters in non-local domains
+  deny message = Restricted characters in address
+       domains = !+local_domains
+       local_parts = ^[./|] : ^.*[@%!] : ^.*/\\.\\./
 
-  accept  hosts         = +relay_from_hosts
-          control       = submission
+  # Require sender verification
+  require verify = sender
 
-  accept  authenticated = *
-          control       = submission/domain=
+  # Accept connections from relay hosts with submission control
+  accept hosts = +relay_from_hosts
+         control = submission
 
-  deny    message       = Rejected because $sender_host_address is in a black list at $dnslist_domain\n$dnslist_text
-          hosts         = !+whitelist
-          dnslists      = ${readfile {/etc/exim4/dnsbl.conf}{:}}
+  # Accept authenticated connections with submission control
+  accept authenticated = *
+         control = submission/domain=
 
-  require message       = relay not permitted
-          domains       = +local_domains : +relay_to_domains
+  # Deny connections from blacklisted hosts (using DNSBL)
+  deny message = Rejected because $sender_host_address is in a black list at $dnslist_domain\n$dnslist_text
+       hosts = !+whitelist
+       dnslists = ${readfile {/etc/exim4/dnsbl.conf}{:}}
 
-  deny    message       = smtp auth requried
-         sender_domains = +local_domains
-         !authenticated = *
+  # Require the recipient domain to be either a local or relay domain
+  require message = relay not permitted
+          domains = +local_domains : +relay_to_domains
 
-  require verify        = recipient
+  # Deny unauthenticated sends from local domains (require SMTP auth)
+  deny message = smtp auth required
+       sender_domains = +local_domains
+       !authenticated = *
 
-.ifdef CLAMD
-  warn    set acl_m0    = no
+  # Require recipient verification
+  require verify = recipient
 
-  warn    condition     = ${if exists {/etc/exim4/domains/$domain/antivirus}{yes}{no}}
-          set acl_m0    = yes
-.endif
+  # Enable antivirus scanning if the domain has antivirus enabled
+  .ifdef CLAMD
+  warn set acl_m0 = no
+  warn condition = ${if exists {/etc/exim4/domains/$domain/antivirus}{yes}{no}}
+       set acl_m0 = yes
+  .endif
 
-.ifdef SPAMASSASSIN
-  warn    set acl_m1    = no
+  # Enable antispam scanning if the domain has antispam enabled
+  .ifdef SPAMASSASSIN
+  warn set acl_m1 = no
+  warn condition = ${if exists {/etc/exim4/domains/$domain/antispam}{yes}{no}}
+       set acl_m1 = yes
+  .endif
 
-  warn    condition     = ${if exists {/etc/exim4/domains/$domain/antispam}{yes}{no}}
-          set acl_m1    = yes
-.endif
-
+  # Accept the recipient
   accept
 
-
+# ACL to validate message data (after RCPT TO, during DATA phase)
 acl_check_data:
-
+  # Deny messages from senders listed in deny_senders
   deny senders = /etc/exim4/deny_senders
 
-.ifdef CLAMD
-  deny   message        = Message contains a virus ($malware_name) and has been rejected
-         malware        = */defer_ok
-         condition      = ${if eq{$acl_m0}{yes}{yes}{no}}
-.endif
+  # Scan for malware if ClamAV is enabled and the domain has antivirus enabled
+  .ifdef CLAMD
+  deny message = Message contains a virus ($malware_name) and has been rejected
+       malware = */defer_ok
+       condition = ${if eq{$acl_m0}{yes}{yes}{no}}
+  .endif
 
-.ifdef SPAMASSASSIN
-  warn   !authenticated = *
-         hosts          = !+relay_from_hosts
-         condition      = ${if < {$message_size}{600K}}
-         condition      = ${if eq{$acl_m1}{yes}{yes}{no}}
-         spam           = nobody:true/defer_ok
-         add_header     = X-Spam-Score: $spam_score_int
-         add_header     = X-Spam-Bar: $spam_bar
-         add_header     = X-Spam-Report: $spam_report
-         set acl_m2     = $spam_score_int
+  # Perform SpamAssassin scanning if enabled, for unauthenticated messages under 600K
+  .ifdef SPAMASSASSIN
+  warn !authenticated = *
+       hosts = !+relay_from_hosts
+       condition = ${if < {$message_size}{600K}}
+       condition = ${if eq{$acl_m1}{yes}{yes}{no}}
+       spam = nobody:true/defer_ok
+       add_header = X-Spam-Score: $spam_score_int
+       add_header = X-Spam-Bar: $spam_bar
+       add_header = X-Spam-Report: $spam_report
+       set acl_m2 = $spam_score_int
 
-  warn   condition      = ${if !eq{$acl_m2}{} {yes}{no}}
-         condition      = ${if >{$acl_m2}{SPAM_SCORE} {yes}{no}}
-         add_header     = X-Spam-Status: Yes
-         message        = SpamAssassin detected spam (from $sender_address to $recipients).
-.endif
+  # Mark messages as spam if the score exceeds the threshold
+  warn condition = ${if !eq{$acl_m2}{} {yes}{no}}
+       condition = ${if >{$acl_m2}{SPAM_SCORE} {yes}{no}}
+       add_header = X-Spam-Status: Yes
+       message = SpamAssassin detected spam (from $sender_address to $recipients).
+  .endif
 
+  # Accept the message
   accept
 
-
+# ACL to validate MIME parts of the message
 acl_check_mime:
-  deny   message        = Blacklisted file extension detected
-         condition      = ${if match {${lc:$mime_filename}}{\N(\.ade|\.adp|\.bat|\.chm|\.cmd|\.com|\.cpl|\.exe|\.hta|\.ins|\.isp|\.jse|\.lib|\.lnk|\.mde|\.msc|\.msp|\.mst|\.pif|\.scr|\.sct|\.shb|\.sys|\.vb|\.vbe|\.vbs|\.vxd|\.wsc|\.wsf|\.wsh|\.jar)$\N}{1}{0}}
+  # Deny messages with blacklisted file extensions
+  deny message = Blacklisted file extension detected
+       condition = ${if match {${lc:$mime_filename}}{\N(\.ade|\.adp|\.bat|\.chm|\.cmd|\.com|\.cpl|\.exe|\.hta|\.ins|\.isp|\.jse|\.lib|\.lnk|\.mde|\.msc|\.msp|\.mst|\.pif|\.scr|\.sct|\.shb|\.sys|\.vb|\.vbe|\.vbs|\.vxd|\.wsc|\.wsf|\.wsh|\.jar)$\N}{1}{0}}
 
+  # Accept the MIME part
   accept
-
-
 
 ######################################################################
 #                   AUTHENTICATION CONFIGURATION                     #
 ######################################################################
+
 begin authenticators
 
+# Dovecot PLAIN authentication
 dovecot_plain:
   driver = dovecot
   public_name = PLAIN
   server_socket = /var/run/dovecot/auth-client
   server_set_id = $auth1
 
+# Dovecot LOGIN authentication
 dovecot_login:
   driver = dovecot
   public_name = LOGIN
   server_socket = /var/run/dovecot/auth-client
   server_set_id = $auth1
 
-
-
 ######################################################################
 #                      ROUTERS CONFIGURATION                         #
 #               Specifies how addresses are handled                  #
 ######################################################################
+
 begin routers
 
+# Uncomment to use a smarthost for outbound mail
 #smarthost:
 #  driver = manualroute
 #  domains = ! +local_domains
@@ -268,20 +369,23 @@ begin routers
 #  no_more
 #  no_verify
 
+# Route non-local domains via DNS lookup
 dnslookup:
   driver = dnslookup
-  # if outbound, and forwarding has been done, use an alternate transport
+  # Use a different transport for forwarded messages
   domains = ! +local_domains
   transport = ${if eq {$local_part@$domain} \
                       {$original_local_part@$original_domain} \
                       {remote_smtp} {remote_forwarded_smtp}}
   no_more
 
+# Deliver spam messages to the user's Spam folder
 localuser_spam:
   driver = accept
   transport = local_spam_delivery
   condition = ${if eq {${if match{$h_X-Spam-Status:}{\N^Yes\N}{yes}{no}}} {${lookup{$local_part}lsearch{/etc/exim4/domains/${lookup{$domain}dsearch{/etc/exim4/domains/}}/passwd}{yes}{no_such_user}}}}
 
+# Handle user .forward files for mail forwarding
 userforward:
   driver = redirect
   check_local_user
@@ -296,6 +400,7 @@ userforward:
   pipe_transport = address_pipe
   reply_transport = address_reply
 
+# Handle procmail for users with a .procmailrc file
 procmail:
   driver = accept
   check_local_user
@@ -303,6 +408,7 @@ procmail:
   transport = procmail
   no_verify
 
+# Send autoreplies if an autoreply message exists
 autoreplay:
   driver = accept
   require_files = /etc/exim4/domains/${lookup{$domain}dsearch{/etc/exim4/domains/}}/autoreply.${local_part}.msg
@@ -311,23 +417,26 @@ autoreplay:
   transport = userautoreply
   unseen
 
+# Handle inbound SRS (Sender Rewriting Scheme) for forwarded messages
 inbound_srs:
-    driver = redirect
-    senders = :
-    domains = +local_domains
-    # detect inbound bounces which are converted to SRS, and decode them
-    condition = ${if inbound_srs {$local_part} {SRS_SECRET}}
-    data = $srs_recipient
+  driver = redirect
+  senders = :
+  domains = +local_domains
+  # Decode SRS addresses for inbound bounces
+  condition = ${if inbound_srs {$local_part} {SRS_SECRET}}
+  data = $srs_recipient
 
+# Fail invalid SRS addresses
 inbound_srs_failure:
-    driver = redirect
-    senders = :
-    domains = +local_domains
-    # detect inbound bounces which look converted to SRS but are invalid
-    condition = ${if inbound_srs {$local_part} {}}
-    allow_fail
-    data = :fail: Invalid SRS recipient address
+  driver = redirect
+  senders = :
+  domains = +local_domains
+  # Fail if the address looks like SRS but is invalid
+  condition = ${if inbound_srs {$local_part} {}}
+  allow_fail
+  data = :fail: Invalid SRS recipient address
 
+# Handle aliases defined in domain alias files
 aliases:
   driver = redirect
   headers_add = X-redirected: yes
@@ -337,16 +446,19 @@ aliases:
   pipe_transport = address_pipe
   unseen
 
+# Handle forward-only accounts
 localuser_fwd_only:
   driver = accept
   transport = devnull
   condition = ${if exists{/etc/exim4/domains/$domain/fwd_only}{${lookup{$local_part}lsearch{/etc/exim4/domains/${lookup{$domain}dsearch{/etc/exim4/domains/}}/fwd_only}{true}{false}}}}
 
+# Deliver to local users
 localuser:
   driver = accept
   transport = local_delivery
   condition = ${lookup{$local_part}lsearch{/etc/exim4/domains/${lookup{$domain}dsearch{/etc/exim4/domains/}}/passwd}{true}{false}}
 
+# Handle catch-all aliases
 catchall:
   driver = redirect
   headers_add = X-redirected: yes
@@ -355,20 +467,22 @@ catchall:
   file_transport = local_delivery
   redirect_router = dnslookup
 
+# Terminate alias processing
 terminate_alias:
   driver = accept
   transport = devnull
   condition = ${lookup{$local_part@$domain}lsearch{/etc/exim4/domains/${lookup{$domain}dsearch{/etc/exim4/domains/}}/aliases}{true}{false}}
 
-
-
 ######################################################################
 #                      TRANSPORTS CONFIGURATION                      #
 ######################################################################
+
 begin transports
 
+# Transport for outbound SMTP delivery
 remote_smtp:
   driver = smtp
+  # Uncomment to set interface and HELO dynamically
   #interface = ${if eq{$acl_m3}{yes}{FIRSTIP}{${lookup{$sender_address_domain}lsearch{/etc/exim4/virtual/interfaces} {$value}{SECONDIP}}}}
   #helo_data = "${if eq{$acl_m3}{yes}{FIRSTHOST}{${lookup{$sending_ip_address}lsearch{/etc/exim4/virtual/helo_data}{$value}{SECONDHOST}}}}"
   dkim_domain = DKIM_DOMAIN
@@ -376,10 +490,11 @@ remote_smtp:
   dkim_private_key = DKIM_PRIVATE_KEY
   dkim_canon = relaxed
   dkim_strict = 0
-  hosts_try_fastopen = 
+  hosts_try_fastopen =
   hosts_try_chunking = !93.188.3.0/24
   message_linelength_limit = 1G
 
+# Transport for forwarded SMTP messages (with SRS rewriting)
 remote_forwarded_smtp:
   driver = smtp
   dkim_domain = DKIM_DOMAIN
@@ -387,13 +502,13 @@ remote_forwarded_smtp:
   dkim_private_key = DKIM_PRIVATE_KEY
   dkim_canon = relaxed
   dkim_strict = 0
-  hosts_try_fastopen = 
+  hosts_try_fastopen =
   hosts_try_chunking = !93.188.3.0/24
   message_linelength_limit = 1G
-  # modify the envelope from, for mails that we forward
   max_rcpt = 1
   return_path = ${srs_encode {SRS_SECRET} {$return_path} {$original_domain}}
 
+# Transport for procmail delivery
 procmail:
   driver = pipe
   command = "/usr/bin/procmail -d $local_part"
@@ -404,6 +519,7 @@ procmail:
   initgroups
   return_output
 
+# Transport for local mail delivery to user mailboxes
 local_delivery:
   driver = appendfile
   maildir_format
@@ -421,6 +537,7 @@ local_delivery:
   quota = ${extract{6}{:}{${lookup{$local_part}lsearch{/etc/exim4/domains/${lookup{$domain}dsearch{/etc/exim4/domains/}}/passwd}}}}M
   quota_warn_threshold = 75%
 
+# Transport for delivering spam messages to the Spam folder
 local_spam_delivery:
   driver = appendfile
   maildir_format
@@ -439,19 +556,23 @@ local_spam_delivery:
   quota_directory = "${extract{5}{:}{${lookup{$local_part}lsearch{/etc/exim4/domains/${lookup{$domain}dsearch{/etc/exim4/domains/}}/passwd}}}}/mail/${lookup{$domain}dsearch{/etc/exim4/domains/}}/${lookup{$local_part}dsearch{${extract{5}{:}{${lookup{$local_part}lsearch{/etc/exim4/domains/${lookup{$domain}dsearch{/etc/exim4/domains/}}/passwd}}}}/mail/${lookup{$domain}dsearch{/etc/exim4/domains/}}}}"
   quota_warn_threshold = 75%
 
+# Transport for piped deliveries (e.g., via aliases)
 address_pipe:
   driver = pipe
   return_output
 
+# Transport for file deliveries (e.g., via .forward files)
 address_file:
   driver = appendfile
   delivery_date_add
   envelope_to_add
   return_path_add
 
+# Transport for autoreplies (e.g., via .forward files)
 address_reply:
   driver = autoreply
 
+# Transport for user-defined autoreplies
 userautoreply:
   driver = autoreply
   file = /etc/exim4/domains/${lookup{$domain}dsearch{/etc/exim4/domains/}}/autoreply.${extract{1}{:}{${lookup{$local_part}lsearch{/etc/exim4/domains/${lookup{$domain}dsearch{/etc/exim4/domains/}}/accounts}}}}.msg
@@ -460,28 +581,26 @@ userautoreply:
   subject = "${if def:h_Subject: {Autoreply: \"${rfc2047:$h_Subject:}\"} {Autoreply Message}}"
   to = "${sender_address}"
 
+# Transport to discard messages (used for devnull routing)
 devnull:
   driver = appendfile
   file = /dev/null
 
-
-
 ######################################################################
 #                      RETRY CONFIGURATION                           #
 ######################################################################
+
 begin retry
 
+# Retry rules for message delivery
 # Address or Domain    Error       Retries
 # -----------------    -----       -------
 *                      *           F,2h,15m; G,16h,1h,1.5; F,4d,6h
 
-
-
 ######################################################################
 #                      REWRITE CONFIGURATION                         #
 ######################################################################
+
 begin rewrite
-
-
 
 ######################################################################

--- a/install/vst-install-debian.sh
+++ b/install/vst-install-debian.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # myVesta Debian installer v 0.9
-
 #----------------------------------------------------------#
-#                  Variables&Functions                     #
+#                  Variables & Functions                   #
 #----------------------------------------------------------#
 export PATH=$PATH:/sbin
 export DEBIAN_FRONTEND=noninteractive
 
+# Define repository and installation paths
 RHOST='apt.myvestacp.com'
 CHOST='c.myvestacp.com'
 VERSION='debian'
@@ -20,6 +20,7 @@ codename="$(cat /etc/os-release |grep VERSION= |cut -f 2 -d \(|cut -f 1 -d \))"
 vestacp="$VESTA/install/$VERSION/$release"
 ARCH="amd64"
 
+# Define software packages based on Debian release
 if [ "$release" -eq 12 ]; then
     software="nginx apache2 apache2-utils
         libapache2-mod-fcgid php-fpm php
@@ -93,7 +94,7 @@ elif [ "$release" -eq 8 ]; then
         unrar-free vim-common net-tools unzip"
 fi
 
-# Defining help function
+# Function to display usage information
 help() {
     echo "Usage: $0 [OPTIONS]
   -a, --apache            Install Apache        [yes|no]  default: yes
@@ -127,8 +128,7 @@ help() {
     exit 1
 }
 
-
-# Defining password-gen function
+# Function to generate a random password
 gen_pass() {
     MATRIX='0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
     if [ -z "$1" ]; then
@@ -143,7 +143,7 @@ gen_pass() {
     echo "$PASS"
 }
 
-# Defning return code check function
+# Function to check the result of a command and exit on failure
 check_result() {
     if [ $1 -ne 0 ]; then
         echo "Error: $2"
@@ -151,7 +151,7 @@ check_result() {
     fi
 }
 
-# Defining function to set default value
+# Function to set a default value for a variable
 set_default_value() {
     eval variable=\$$1
     if [ -z "$variable" ]; then
@@ -162,7 +162,7 @@ set_default_value() {
     fi
 }
 
-# Define function to set default language value
+# Function to set a default language value
 set_default_lang() {
     if [ -z "$lang" ]; then
         eval lang=$1
@@ -177,8 +177,9 @@ set_default_lang() {
     fi
 }
 
+# Function to ensure a service is enabled on startup
 ensure_startup() {
-    echo "- making sure startup is enabled for: $1"
+    echo "- Making sure startup is enabled for: $1"
     currentservice=$1
     unit_files="$(systemctl list-unit-files |grep $currentservice)"
     if [[ "$unit_files" =~ "disabled" ]]; then
@@ -186,8 +187,9 @@ ensure_startup() {
     fi
 }
 
+# Function to ensure a service is started
 ensure_start() {
-    echo "- making sure $1 is started"
+    echo "- Making sure $1 is started"
     currentservice=$1
     systemctl status $currentservice.service > /dev/null 2>&1
     r=$?
@@ -201,10 +203,10 @@ ensure_start() {
 #                    Verifications                         #
 #----------------------------------------------------------#
 
-# Creating temporary file
+# Create a temporary file for storing intermediate data
 tmpfile=$(mktemp -p /tmp)
 
-# Translating argument to --gnu-long-options
+# Translate arguments to long options
 for arg; do
     delim=""
     case "$arg" in
@@ -242,7 +244,7 @@ for arg; do
 done
 eval set -- "$args"
 
-# Parsing arguments
+# Parse command-line arguments
 while getopts "a:n:w:v:j:k:m:g:d:x:z:c:t:i:b:r:o:q:l:y:s:e:p:u:1:fh" Option; do
     case $Option in
         a) apache=$OPTARG ;;            # Apache
@@ -277,7 +279,7 @@ while getopts "a:n:w:v:j:k:m:g:d:x:z:c:t:i:b:r:o:q:l:y:s:e:p:u:1:fh" Option; do
     esac
 done
 
-# Defining default software stack
+# Set default values for software stack
 set_default_value 'nginx' 'yes'
 set_default_value 'apache' 'yes'
 set_default_value 'phpfpm' 'no'
@@ -304,11 +306,7 @@ set_default_value 'quota' 'no'
 set_default_value 'interactive' 'yes'
 set_default_lang 'en'
 
-# Checking software conflicts
-# if [ "$phpfpm" = 'yes' ]; then
-#     apache='no'
-#     nginx='yes'
-# fi
+# Resolve software conflicts
 if [ "$proftpd" = 'yes' ]; then
     vsftpd='no'
 fi
@@ -324,12 +322,12 @@ if [ "$mysql8" = 'yes' ]; then
     mysql='no'
 fi
 
-# Checking root permissions
+# Check for root permissions
 if [ "x$(id -u)" != 'x0' ]; then
     check_error 1 "Script can be run executed only by root"
 fi
 
-# Checking admin user account
+# Check for existing admin user
 if [ ! -z "$(grep ^admin: /etc/passwd)" ] && [ -z "$force" ]; then
     echo 'Please remove admin user account before proceeding.'
     echo 'If you want to do it automatically run installer with -f option:'
@@ -337,33 +335,33 @@ if [ ! -z "$(grep ^admin: /etc/passwd)" ] && [ -z "$force" ]; then
     check_result 1 "User admin exists"
 fi
 
+# Update apt repositories
 echo "Updating apt, please wait..."
 apt-get update > /dev/null 2>&1
 
-# Checking wget
+# Install wget if not present
 if [ ! -e '/usr/bin/wget' ]; then
     apt-get -y install wget > /dev/null 2>&1
     check_result $? "Can't install wget"
 fi
 
-# Check if gnupg2 is installed
+# Install gnupg2 if not present
 if [ $(dpkg-query -W -f='${Status}' gnupg2 2>/dev/null | grep -c "ok installed") -eq 0 ]; then
     apt-get -y install gnupg2 > /dev/null 2>&1
 fi
 
 # Check if apparmor is installed
-# This check is borrowed from HestiaCP
 if [ $(dpkg-query -W -f='${Status}' apparmor 2>/dev/null | grep -c "ok installed") -eq 0 ]; then
     apparmor='no'
 else
     apparmor='yes'
 fi
 
-# Checking repository availability
+# Check repository availability
 wget -q "apt.myvestacp.com/deb_signing.key" -O /dev/null
 check_result $? "No access to Vesta repository"
 
-# Check installed packages
+# Check for installed conflicting packages
 tmpfile=$(mktemp -p /tmp)
 dpkg --get-selections > $tmpfile
 for pkg in exim4 mysql-server apache2 nginx vesta; do
@@ -396,12 +394,11 @@ if [ ! -z "$conflicts" ] && [ -z "$force" ]; then
     check_result 1 "Control Panel should be installed on clean server."
 fi
 
-
 #----------------------------------------------------------#
 #                       Brief Info                         #
 #----------------------------------------------------------#
 
-# Printing nice ascii aslogo
+# Display installation banner
 clear
 echo
 echo "                __     __        _        "
@@ -416,7 +413,7 @@ echo -e "\n\n"
 
 echo 'Following software will be installed on your system:'
 
-# Web stack
+# Display web stack information
 if [ "$nginx" = 'yes' ]; then
     echo '   - nginx Web server'
 fi
@@ -431,12 +428,12 @@ if [ "$phpfpm"  = 'yes' ]; then
     echo '   - PHP-FPM service for PHP processing'
 fi
 
-# DNS stack
+# Display DNS stack information
 if [ "$named" = 'yes' ]; then
     echo '   - Bind9 DNS service'
 fi
 
-# Mail Stack
+# Display mail stack information
 if [ "$exim" = 'yes' ]; then
     echo -n '   - Exim4 mail server'
     if [ "$clamd" = 'yes'  ] ||  [ "$spamd" = 'yes' ] ; then
@@ -453,7 +450,7 @@ if [ "$exim" = 'yes' ]; then
     fi
 fi
 
-# DB stack
+# Display database stack information
 if [ "$mysql" = 'yes' ]; then
     echo '   - MariaDB Database server'
 fi
@@ -463,11 +460,8 @@ fi
 if [ "$postgresql" = 'yes' ]; then
     echo '   - PostgreSQL Database server'
 fi
-# if [ "$mongodb" = 'yes' ]; then
-#    echo '   - MongoDB Database Server'
-# fi
 
-# FTP stack
+# Display FTP stack information
 if [ "$vsftpd" = 'yes' ]; then
     echo '   - Vsftpd FTP service'
 fi
@@ -475,12 +469,12 @@ if [ "$proftpd" = 'yes' ]; then
     echo '   - ProFTPD FTP service'
 fi
 
-# Softaculous
+# Display Softaculous information
 if [ "$softaculous" = 'yes' ]; then
     echo '   - Softaculous Plugin'
 fi
 
-# Firewall stack
+# Display firewall stack information
 if [ "$iptables" = 'yes' ]; then
     echo -n '   - iptables firewall'
 fi
@@ -489,7 +483,7 @@ if [ "$iptables" = 'yes' ] && [ "$fail2ban" = 'yes' ]; then
 fi
 echo -e "\n\n"
 
-# Asking for confirmation to proceed
+# Ask for confirmation to proceed in interactive mode
 if [ "$interactive" = 'yes' ]; then
     read -p 'Would you like to continue [y/n]: ' answer
     if [ "$answer" != 'y' ] && [ "$answer" != 'Y'  ]; then
@@ -497,40 +491,40 @@ if [ "$interactive" = 'yes' ]; then
         exit 1
     fi
 
-    # Asking for contact email
+    # Prompt for admin email if not provided
     if [ -z "$email" ]; then
         read -p 'Please enter admin email address: ' email
     fi
 
-    # Asking for secret URL
+    # Prompt for secret URL if not provided
     if [ -z "$secret_url" ]; then
         echo 'Please enter secret URL address for hosting panel (or press enter for none).'
         echo 'Secret URL must be without special characters, just letters and numbers. Example: mysecret8205'
         read -p 'Enter secret URL address: ' secret_url
     fi
 
-    # Asking for Vesta port
+    # Prompt for Vesta port if not provided
     if [ -z "$port" ]; then
         read -p 'Please enter Vesta port number (press enter for 8083): ' port
     fi
 
-    # Asking to set FQDN hostname
+    # Prompt for FQDN hostname if not provided
     if [ -z "$servername" ]; then
         read -p "Please enter FQDN hostname [$(hostname)]: " servername
     fi
 fi
 
-# Generating admin password if it wasn't set
+# Generate admin password if not provided
 if [ -z "$vpass" ]; then
     vpass=$(gen_pass)
 fi
 
-# Set hostname if it wasn't set
+# Set hostname if not provided
 if [ -z "$servername" ]; then
     servername=$(hostname -f)
 fi
 
-# Set FQDN if it wasn't set
+# Validate and set FQDN hostname
 mask1='(([[:alnum:]](-?[[:alnum:]])*)\.)'
 mask2='*[[:alnum:]](-?[[:alnum:]])+\.[[:alnum:]]{2,}'
 if ! [[ "$servername" =~ ^${mask1}${mask2}$ ]]; then
@@ -544,29 +538,44 @@ fi
 echo "$servername" > /etc/hostname
 hostname $servername
 
-# Set email if it wasn't set
+# Derive Exim primary_hostname as mail.<base domain>
+# Extract the base domain (last two parts, e.g., server.example.com -> example.com)
+base_domain=$(echo $servername | rev | cut -d'.' -f1-2 | rev)
+# Handle cases with more complex TLDs (e.g., server.example.co.uk -> example.co.uk)
+if [[ $servername =~ \.[a-z]+\.[a-z]+\.[a-z]+$ ]]; then
+    # For cases like server.example.co.uk, take the last three parts
+    base_domain=$(echo $servername | rev | cut -d'.' -f1-3 | rev)
+fi
+# Set primary_hostname to mail.<base domain>
+exim_hostname="mail.$base_domain"
+# Fallback to mail.example.com if base_domain is invalid
+if [ -z "$base_domain" ] || ! [[ "$base_domain" =~ ^[a-zA-Z0-9-]+\.[a-zA-Z]{2,}$ ]]; then
+    exim_hostname="mail.example.com"
+fi
+
+# Set email if not provided
 if [ -z "$email" ]; then
     email="admin@$servername"
 fi
 
-# Set port if it wasn't set
+# Set port if not provided
 if [ -z "$port" ]; then
     port="8083"
 fi
 
-# Defining backup directory
+# Define backup directory
 vst_backups="/root/vst_install_backups/$(date +%s)"
 echo "Installation backup directory: $vst_backups"
 
-# Printing start message and sleeping for 5 seconds
+# Display start message and wait for 5 seconds
 echo -e "\n\n\n\nInstallation will take about 15 minutes ...\n"
 sleep 5
 
-
 #----------------------------------------------------------#
-#                      Checking swap                       #
+#                      Checking Swap                       #
 #----------------------------------------------------------#
 
+# Enable swap on small instances if not already enabled
 if [ -z "$(swapon -s)" ] && [ $memory -lt 1000000 ]; then
     echo "== Checking swap on small instances"
     fallocate -l 1G /swapfile
@@ -576,9 +585,8 @@ if [ -z "$(swapon -s)" ] && [ $memory -lt 1000000 ]; then
     echo "/swapfile   none    swap    sw    0   0" >> /etc/fstab
 fi
 
-
 #----------------------------------------------------------#
-#                   Install repository                     #
+#                   Install Repository                     #
 #----------------------------------------------------------#
 
 echo "=== Updating system (apt-get -y upgrade)"
@@ -587,20 +595,14 @@ check_result $? 'apt-get upgrade failed'
 
 echo "=== Installing nginx repo"
 apt="/etc/apt/sources.list.d"
-# echo "deb http://nginx.org/packages/debian/ $codename nginx" > $apt/nginx.list
-# wget http://nginx.org/keys/nginx_signing.key -O /tmp/nginx_signing.key
-# apt-key add /tmp/nginx_signing.key
 echo "deb [arch=$ARCH signed-by=/usr/share/keyrings/nginx-keyring.gpg] https://nginx.org/packages/mainline/$VERSION/ $codename nginx" > $apt/nginx.list
 curl -s https://nginx.org/keys/nginx_signing.key | gpg --dearmor | tee /usr/share/keyrings/nginx-keyring.gpg > /dev/null 2>&1
 
 echo "=== Installing myVesta repo"
-# echo "deb http://$RHOST/$codename/ $codename vesta" > $apt/vesta.list
-# wget $CHOST/deb_signing.key -O deb_signing.key
-# apt-key add deb_signing.key
 echo "deb [arch=$ARCH signed-by=/usr/share/keyrings/myvesta-keyring.gpg] https://$RHOST/$codename/ $codename vesta" > $apt/vesta.list
 curl -s $CHOST/deb_signing.key | gpg --dearmor | tee /usr/share/keyrings/myvesta-keyring.gpg > /dev/null 2>&1
 
-# Installing jessie backports
+# Install jessie backports for Debian 8
 if [ "$release" -eq 8 ]; then
     if [ ! -e /etc/apt/apt.conf ]; then
         echo 'Acquire::Check-Valid-Until "false";' >> /etc/apt/apt.conf
@@ -610,7 +612,6 @@ if [ "$release" -eq 8 ]; then
             /etc/apt/sources.list.d/backports.list
     fi
 fi
-
 
 #----------------------------------------------------------#
 #                         Backup                           #
@@ -625,73 +626,72 @@ mkdir nginx apache2 php php5 php5-fpm vsftpd proftpd bind exim4 dovecot clamd
 mkdir spamassassin mysql postgresql mongodb vesta
 
 echo "=== Backing up old configs"
-# Backing up Nginx configuration
+# Backup Nginx configuration
 service nginx stop > /dev/null 2>&1
 cp -r /etc/nginx/* $vst_backups/nginx >/dev/null 2>&1
 
-# Backing up Apache configuration
+# Backup Apache configuration
 service apache2 stop > /dev/null 2>&1
 cp -r /etc/apache2/* $vst_backups/apache2 > /dev/null 2>&1
 rm -f /etc/apache2/conf.d/* > /dev/null 2>&1
 
-# Backing up PHP configuration
+# Backup PHP configuration
 cp /etc/php.ini $vst_backups/php > /dev/null 2>&1
 cp -r /etc/php.d  $vst_backups/php > /dev/null 2>&1
 
-# Backing up PHP configuration
+# Backup PHP5-FPM configuration
 service php5-fpm stop >/dev/null 2>&1
 cp /etc/php5/* $vst_backups/php5 > /dev/null 2>&1
 rm -f /etc/php5/fpm/pool.d/* >/dev/null 2>&1
 
-# Backing up Bind configuration
+# Backup Bind configuration
 service bind9 stop > /dev/null 2>&1
 cp -r /etc/bind/* $vst_backups/bind > /dev/null 2>&1
 
-# Backing up Vsftpd configuration
+# Backup Vsftpd configuration
 service vsftpd stop > /dev/null 2>&1
 cp /etc/vsftpd.conf $vst_backups/vsftpd > /dev/null 2>&1
 
-# Backing up ProFTPD configuration
+# Backup ProFTPD configuration
 service proftpd stop > /dev/null 2>&1
 cp /etc/proftpd.conf $vst_backups/proftpd >/dev/null 2>&1
 
-# Backing up Exim configuration
+# Backup Exim configuration
 service exim4 stop > /dev/null 2>&1
 cp -r /etc/exim4/* $vst_backups/exim4 > /dev/null 2>&1
 
-# Backing up ClamAV configuration
+# Backup ClamAV configuration
 service clamav-daemon stop > /dev/null 2>&1
 cp -r /etc/clamav/* $vst_backups/clamav > /dev/null 2>&1
 
-# Backing up SpamAssassin configuration
+# Backup SpamAssassin configuration
 service spamassassin stop > /dev/null 2>&1
 cp -r /etc/spamassassin/* $vst_backups/spamassassin > /dev/null 2>&1
 
-# Backing up Dovecot configuration
+# Backup Dovecot configuration
 service dovecot stop > /dev/null 2>&1
 cp /etc/dovecot.conf $vst_backups/dovecot > /dev/null 2>&1
 cp -r /etc/dovecot/* $vst_backups/dovecot > /dev/null 2>&1
 
-# Backing up MySQL/MariaDB configuration and data
+# Backup MySQL/MariaDB configuration and data
 service mysql stop > /dev/null 2>&1
 killall -9 mysqld > /dev/null 2>&1
 mv /var/lib/mysql $vst_backups/mysql/mysql_datadir > /dev/null 2>&1
 cp -r /etc/mysql/* $vst_backups/mysql > /dev/null 2>&1
 mv -f /root/.my.cnf $vst_backups/mysql > /dev/null 2>&1
 
-# Backup vesta
+# Backup Vesta
 service vesta stop > /dev/null 2>&1
 cp -r $VESTA/* $vst_backups/vesta > /dev/null 2>&1
 apt-get -y remove vesta vesta-nginx vesta-php > /dev/null 2>&1
 apt-get -y purge vesta vesta-nginx vesta-php > /dev/null 2>&1
 rm -rf $VESTA > /dev/null 2>&1
 
-
 #----------------------------------------------------------#
 #                     Package Excludes                     #
 #----------------------------------------------------------#
 
-# Excluding packages
+# Exclude packages based on user choices
 if [ "$nginx" = 'no'  ]; then
     software=$(echo "$software" | sed -e "s/^nginx//")
 fi
@@ -705,10 +705,6 @@ if [ "$apache" = 'no' ]; then
     software=$(echo "$software" | sed -e "s/libapache2-mod-php5//")
     software=$(echo "$software" | sed -e "s/libapache2-mod-php//")
 fi
-# if [ "$phpfpm" = 'no' ]; then
-    # software=$(echo "$software" | sed -e "s/php5-fpm//")
-    # software=$(echo "$software" | sed -e "s/php-fpm//")
-# fi
 if [ "$vsftpd" = 'no' ]; then
     software=$(echo "$software" | sed -e "s/vsftpd//")
 fi
@@ -754,37 +750,34 @@ fi
 if [ "$mysql8" = 'yes' ]; then
     echo "=== Preparing MySQL 8 apt repo"
     if [ "$release" -lt 12 ]; then
-	    software=$(echo "$software" | sed -e 's/exim4-daemon-heavy//')
-	    software=$(echo "$software" | sed -e 's/exim4//')
-	    #software="$software php-mysql roundcube-mysql"
-	    echo "### THIS FILE IS AUTOMATICALLY CONFIGURED ###" > /etc/apt/sources.list.d/mysql.list
-	    echo "# You may comment out entries below, but any other modifications may be lost." >> /etc/apt/sources.list.d/mysql.list
-	    echo "# Use command 'dpkg-reconfigure mysql-apt-config' as root for modifications." >> /etc/apt/sources.list.d/mysql.list
-	    echo "deb http://repo.mysql.com/apt/debian/ $codename mysql-apt-config" >> /etc/apt/sources.list.d/mysql.list
-	    echo "deb http://repo.mysql.com/apt/debian/ $codename mysql-8.0" >> /etc/apt/sources.list.d/mysql.list
-	    echo "deb http://repo.mysql.com/apt/debian/ $codename mysql-tools" >> /etc/apt/sources.list.d/mysql.list
-	    echo "#deb http://repo.mysql.com/apt/debian/ $codename mysql-tools-preview" >> /etc/apt/sources.list.d/mysql.list
-	    echo "deb-src http://repo.mysql.com/apt/debian/ $codename mysql-8.0" >> /etc/apt/sources.list.d/mysql.list
-	
-	    # apt-key adv --keyserver pgp.mit.edu --recv-keys 3A79BD29
-	    key="467B942D3A79BD29"
-	    readonly key
-	    GNUPGHOME="$(mktemp -d)"
-	    export GNUPGHOME
-	    for keyserver in $(shuf -e ha.pool.sks-keyservers.net hkp://p80.pool.sks-keyservers.net:80 keyserver.ubuntu.com hkp://keyserver.ubuntu.com:80)
-	    do
-	        gpg --keyserver "${keyserver}" --recv-keys "${key}" 2>&1 && break
-	    done
-	    gpg --export "${key}" > /etc/apt/trusted.gpg.d/mysql.gpg
-	    gpgconf --kill all
-	    rm -rf "${GNUPGHOME}"
-	    unset GNUPGHOME
-     else
-            # check latest on: https://dev.mysql.com/downloads/repo/apt/
-	    wget https://dev.mysql.com/get/mysql-apt-config_0.8.34-1_all.deb
-            dpkg -i mysql-apt-config_0.8.34-1_all.deb
-     fi
-    
+        software=$(echo "$software" | sed -e 's/exim4-daemon-heavy//')
+        software=$(echo "$software" | sed -e 's/exim4//')
+        echo "### THIS FILE IS AUTOMATICALLY CONFIGURED ###" > /etc/apt/sources.list.d/mysql.list
+        echo "# You may comment out entries below, but any other modifications may be lost." >> /etc/apt/sources.list.d/mysql.list
+        echo "# Use command 'dpkg-reconfigure mysql-apt-config' as root for modifications." >> /etc/apt/sources.list.d/mysql.list
+        echo "deb http://repo.mysql.com/apt/debian/ $codename mysql-apt-config" >> /etc/apt/sources.list.d/mysql.list
+        echo "deb http://repo.mysql.com/apt/debian/ $codename mysql-8.0" >> /etc/apt/sources.list.d/mysql.list
+        echo "deb http://repo.mysql.com/apt/debian/ $codename mysql-tools" >> /etc/apt/sources.list.d/mysql.list
+        echo "#deb http://repo.mysql.com/apt/debian/ $codename mysql-tools-preview" >> /etc/apt/sources.list.d/mysql.list
+        echo "deb-src http://repo.mysql.com/apt/debian/ $codename mysql-8.0" >> /etc/apt/sources.list.d/mysql.list
+
+        key="467B942D3A79BD29"
+        readonly key
+        GNUPGHOME="$(mktemp -d)"
+        export GNUPGHOME
+        for keyserver in $(shuf -e ha.pool.sks-keyservers.net hkp://p80.pool.sks-keyservers.net:80 keyserver.ubuntu.com hkp://keyserver.ubuntu.com:80)
+        do
+            gpg --keyserver "${keyserver}" --recv-keys "${key}" 2>&1 && break
+        done
+        gpg --export "${key}" > /etc/apt/trusted.gpg.d/mysql.gpg
+        gpgconf --kill all
+        rm -rf "${GNUPGHOME}"
+        unset GNUPGHOME
+    else
+        wget https://dev.mysql.com/get/mysql-apt-config_0.8.34-1_all.deb
+        dpkg -i mysql-apt-config_0.8.34-1_all.deb
+    fi
+
     mpass=$(gen_pass)
     debconf-set-selections <<< "mysql-community-server mysql-community-server/root-pass password $mpass"
     debconf-set-selections <<< "mysql-community-server mysql-community-server/re-root-pass password $mpass"
@@ -804,9 +797,8 @@ if [ "$iptables" = 'no' ] || [ "$fail2ban" = 'no' ]; then
     software=$(echo "$software" | sed -e 's/fail2ban//')
 fi
 
-
 #----------------------------------------------------------#
-#                     Install packages                     #
+#                     Install Packages                     #
 #----------------------------------------------------------#
 
 # Update system packages
@@ -820,7 +812,6 @@ chmod a+x /usr/sbin/policy-rc.d
 if [ "$mysql8" = 'yes' ]; then
     echo "=== Installing MySQL 8"
     apt-get -y install mysql-server mysql-client mysql-common
-    #update-rc.d mysql defaults
     currentservice='mysql'
     ensure_startup $currentservice
     ensure_start $currentservice
@@ -830,9 +821,7 @@ if [ "$mysql8" = 'yes' ]; then
 fi
 
 echo "=== Installing all apt packages"
-# echo "apt-get -y install $software"
 apt-get -y install $software
-
 check_result $? "apt-get install failed"
 
 if [ "$mysql8" = 'yes' ]; then
@@ -841,7 +830,6 @@ if [ "$mysql8" = 'yes' ]; then
         apt-get -y install exim4 exim4-daemon-heavy
     fi
     echo "=== Installing phpmyadmin"
-    #apt-get -y --no-install-recommends install phpmyadmin
     apt-get -y install phpmyadmin
 fi
 
@@ -856,20 +844,20 @@ if [ "$release" -gt 11 ]; then
 fi
 
 #----------------------------------------------------------#
-#                     Configure system                     #
+#                     Configure System                     #
 #----------------------------------------------------------#
 
-echo "== Enable SSH password auth"
+echo "== Enable SSH password authentication"
 sed -i "s/rdAuthentication no/rdAuthentication yes/g" /etc/ssh/sshd_config
 systemctl restart ssh
 
 echo "== Disable awstats cron"
 rm -f /etc/cron.d/awstats
 
-echo "== Set directory color"
+echo "== Set directory color for ls command"
 echo 'LS_COLORS="$LS_COLORS:di=00;33"' >> /etc/profile
 
-echo "== Register /sbin/nologin and /usr/sbin/nologin"
+echo "== Register /sbin/nologin and /usr/sbin/nologin in /etc/shells"
 echo "/sbin/nologin" >> /etc/shells
 echo "/usr/sbin/nologin" >> /etc/shells
 
@@ -880,14 +868,14 @@ chmod 775 /etc/cron.daily/ntpdate
 ntpdate -s pool.ntp.org
 
 if [ "$release" -eq 9 ]; then
-  # Setup rssh
-  if [ -z "$(grep /usr/bin/rssh /etc/shells)" ]; then
-      echo /usr/bin/rssh >> /etc/shells
-  fi
-  sed -i 's/#allowscp/allowscp/' /etc/rssh.conf
-  sed -i 's/#allowsftp/allowsftp/' /etc/rssh.conf
-  sed -i 's/#allowrsync/allowrsync/' /etc/rssh.conf
-  chmod 755 /usr/bin/rssh
+    # Setup rssh for Debian 9
+    if [ -z "$(grep /usr/bin/rssh /etc/shells)" ]; then
+        echo /usr/bin/rssh >> /etc/shells
+    fi
+    sed -i 's/#allowscp/allowscp/' /etc/rssh.conf
+    sed -i 's/#allowsftp/allowsftp/' /etc/rssh.conf
+    sed -i 's/#allowrsync/allowrsync/' /etc/rssh.conf
+    chmod 755 /usr/bin/rssh
 fi
 
 #----------------------------------------------------------#
@@ -899,7 +887,7 @@ mkdir -p /etc/sudoers.d
 cp -f $vestacp/sudo/admin /etc/sudoers.d/
 chmod 440 /etc/sudoers.d/admin
 
-echo "== Configuring system env"
+echo "== Configuring system environment for Vesta"
 echo "export VESTA='$VESTA'" > /etc/profile.d/vesta.sh
 chmod 755 /etc/profile.d/vesta.sh
 source /etc/profile.d/vesta.sh
@@ -907,10 +895,10 @@ echo 'PATH=$PATH:'$VESTA'/bin' >> /root/.bash_profile
 echo 'export PATH' >> /root/.bash_profile
 source /root/.bash_profile
 
-echo "== Copying logrotate for myVesta logs"
+echo "== Copying logrotate configuration for Vesta logs"
 cp -f $vestacp/logrotate/vesta /etc/logrotate.d/
 
-echo "== Building directory tree and creating some blank files for myVesta"
+echo "== Building directory tree and creating blank files for Vesta"
 mkdir -p $VESTA/conf $VESTA/log $VESTA/ssl $VESTA/data/ips \
     $VESTA/data/queue $VESTA/data/users $VESTA/data/firewall \
     $VESTA/data/sessions
@@ -930,7 +918,7 @@ rm -f $VESTA/conf/vesta.conf 2>/dev/null
 touch $VESTA/conf/vesta.conf
 chmod 660 $VESTA/conf/vesta.conf
 
-# WEB stack
+# Configure Vesta web stack
 if [ "$apache" = 'yes' ] && [ "$nginx" = 'no' ] ; then
     echo "WEB_SYSTEM='apache2'" >> $VESTA/conf/vesta.conf
     echo "WEB_RGROUPS='www-data'" >> $VESTA/conf/vesta.conf
@@ -967,7 +955,7 @@ if [ "$apache" = 'no' ] && [ "$nginx"  = 'yes' ]; then
     echo "STATS_SYSTEM='webalizer,awstats'" >> $VESTA/conf/vesta.conf
 fi
 
-# FTP stack
+# Configure Vesta FTP stack
 if [ "$vsftpd" = 'yes' ]; then
     echo "FTP_SYSTEM='vsftpd'" >> $VESTA/conf/vesta.conf
 fi
@@ -975,12 +963,12 @@ if [ "$proftpd" = 'yes' ]; then
     echo "FTP_SYSTEM='proftpd'" >> $VESTA/conf/vesta.conf
 fi
 
-# DNS stack
+# Configure Vesta DNS stack
 if [ "$named" = 'yes' ]; then
     echo "DNS_SYSTEM='bind9'" >> $VESTA/conf/vesta.conf
 fi
 
-# Mail stack
+# Configure Vesta mail stack
 if [ "$exim" = 'yes' ]; then
     echo "MAIL_SYSTEM='exim4'" >> $VESTA/conf/vesta.conf
     if [ "$clamd" = 'yes'  ]; then
@@ -998,10 +986,10 @@ if [ "$exim" = 'yes' ]; then
     fi
 fi
 
-# CRON daemon
+# Configure Vesta cron daemon
 echo "CRON_SYSTEM='cron'" >> $VESTA/conf/vesta.conf
 
-# Firewall stack
+# Configure Vesta firewall stack
 if [ "$iptables" = 'yes' ]; then
     echo "FIREWALL_SYSTEM='iptables'" >> $VESTA/conf/vesta.conf
 fi
@@ -1009,18 +997,18 @@ if [ "$iptables" = 'yes' ] && [ "$fail2ban" = 'yes' ]; then
     echo "FIREWALL_EXTENSION='fail2ban'" >> $VESTA/conf/vesta.conf
 fi
 
-# Disk quota
+# Configure disk quota
 if [ "$quota" = 'yes' ]; then
     echo "DISK_QUOTA='yes'" >> $VESTA/conf/vesta.conf
 fi
 
-# Backups
+# Configure backups
 echo "BACKUP_SYSTEM='local'" >> $VESTA/conf/vesta.conf
 
-# Language
+# Set language
 echo "LANGUAGE='$lang'" >> $VESTA/conf/vesta.conf
 
-# Version
+# Set version
 echo "VERSION='0.9.8'" >> $VESTA/conf/vesta.conf
 
 echo "== Copying packages"
@@ -1029,8 +1017,9 @@ cp -rf $vestacp/packages $VESTA/data/
 echo "== Copying templates"
 cp -rf $vestacp/templates $VESTA/data/
 
+# Symlink missing templates for specific Debian versions
 if [ "$release" -eq 10 ]; then
-    echo "== Symlink missing templates"
+    echo "== Symlink missing templates for Debian 10"
     ln -s /usr/local/vesta/data/templates/web/nginx/hosting.sh /usr/local/vesta/data/templates/web/nginx/default.sh
     ln -s /usr/local/vesta/data/templates/web/nginx/hosting.tpl /usr/local/vesta/data/templates/web/nginx/default.tpl
     ln -s /usr/local/vesta/data/templates/web/nginx/hosting.stpl /usr/local/vesta/data/templates/web/nginx/default.stpl
@@ -1046,7 +1035,7 @@ if [ "$release" -eq 10 ]; then
     ln  -s /usr/local/vesta/data/templates/web/nginx/php-fpm/default.tpl /usr/local/vesta/data/templates/web/nginx/php-fpm/PHP-FPM-73.tpl
 fi
 if [ "$release" -eq 11 ]; then
-    echo "== Symlink missing templates"
+    echo "== Symlink missing templates for Debian 11"
     ln -s /usr/local/vesta/data/templates/web/nginx/hosting.sh /usr/local/vesta/data/templates/web/nginx/default.sh
     ln -s /usr/local/vesta/data/templates/web/nginx/hosting.tpl /usr/local/vesta/data/templates/web/nginx/default.tpl
     ln -s /usr/local/vesta/data/templates/web/nginx/hosting.stpl /usr/local/vesta/data/templates/web/nginx/default.stpl
@@ -1062,7 +1051,7 @@ if [ "$release" -eq 11 ]; then
     ln  -s /usr/local/vesta/data/templates/web/nginx/php-fpm/default.tpl /usr/local/vesta/data/templates/web/nginx/php-fpm/PHP-FPM-74.tpl
 fi
 if [ "$release" -eq 12 ]; then
-    echo "== Symlink missing templates"
+    echo "== Symlink missing templates for Debian 12"
     ln -s /usr/local/vesta/data/templates/web/nginx/hosting.sh /usr/local/vesta/data/templates/web/nginx/default.sh
     ln -s /usr/local/vesta/data/templates/web/nginx/hosting.tpl /usr/local/vesta/data/templates/web/nginx/default.tpl
     ln -s /usr/local/vesta/data/templates/web/nginx/hosting.stpl /usr/local/vesta/data/templates/web/nginx/default.stpl
@@ -1078,7 +1067,7 @@ if [ "$release" -eq 12 ]; then
     ln  -s /usr/local/vesta/data/templates/web/nginx/php-fpm/default.tpl /usr/local/vesta/data/templates/web/nginx/php-fpm/PHP-FPM-82.tpl
 fi
 
-echo "== Set nameservers address"
+echo "== Set nameservers address in default package"
 sed -i "s/YOURHOSTNAME1/ns1.$servername/" /usr/local/vesta/data/packages/default.pkg
 sed -i "s/YOURHOSTNAME2/ns2.$servername/" /usr/local/vesta/data/packages/default.pkg
 sed -i "s/ns1.domain.tld/ns1.$servername/" /usr/local/vesta/data/packages/default.pkg
@@ -1096,11 +1085,11 @@ cp -rf $vestacp/firewall $VESTA/data/
 echo "== Configuring server hostname: $servername"
 $VESTA/bin/v-change-sys-hostname $servername 2>/dev/null
 
-echo "== Generating myVesta unsigned SSL certificate"
+echo "== Generating Vesta unsigned SSL certificate"
 $VESTA/bin/v-generate-ssl-cert $(hostname) $email 'US' 'California' \
      'San Francisco' 'myVesta Control Panel' 'IT' > /tmp/vst.pem
 
-# Parsing certificate file
+# Parse SSL certificate file
 crt_end=$(grep -n "END CERTIFICATE-" /tmp/vst.pem |cut -f 1 -d:)
 if [ "$release" -lt 12 ]; then
     key_start=$(grep -n "BEGIN RSA" /tmp/vst.pem |cut -f 1 -d:)
@@ -1116,7 +1105,6 @@ sed -n "$key_start,${key_end}p" /tmp/vst.pem > certificate.key
 chown root:mail $VESTA/ssl/*
 chmod 660 $VESTA/ssl/*
 rm /tmp/vst.pem
-
 
 #----------------------------------------------------------#
 #                     Configure Nginx                      #
@@ -1134,18 +1122,15 @@ if [ "$nginx" = 'yes' ]; then
     cp -f $vestacp/nginx/webmail.inc /etc/nginx/conf.d/
     cp -f $vestacp/logrotate/nginx /etc/logrotate.d/
     
-    # default user/pass for private-hosting.tpl: private / folder
+    # Default user/pass for private-hosting.tpl: private / folder
     echo 'private:$apr1$0MYnchM5$yVi/OTfp7o3lGNst/a8.90' > /etc/nginx/.htpasswd
     
     echo > /etc/nginx/conf.d/vesta.conf
     mkdir -p /var/log/nginx/domains
-    #update-rc.d nginx defaults
-    #service nginx start
     currentservice='nginx'
     ensure_startup $currentservice
     ensure_start $currentservice
 fi
-
 
 #----------------------------------------------------------#
 #                    Configure Apache                      #
@@ -1157,10 +1142,8 @@ if [ "$apache" = 'yes'  ]; then
     cp -f $vestacp/apache2/status.conf /etc/apache2/mods-enabled/
     cp -f  $vestacp/logrotate/apache2 /etc/logrotate.d/
     a2enmod rewrite
-    # a2enmod suexec
     a2enmod ssl
     a2enmod actions
-    # a2enmod ruid2
     a2enmod headers
     a2enmod expires
     a2enmod proxy_fcgi setenvif
@@ -1169,24 +1152,18 @@ if [ "$apache" = 'yes'  ]; then
     echo "# Powered by vesta" > /etc/apache2/sites-available/default
     echo "# Powered by vesta" > /etc/apache2/sites-available/default-ssl
     echo "# Powered by vesta" > /etc/apache2/ports.conf
-    # echo -e "/home\npublic_html/cgi-bin" > /etc/apache2/suexec/www-data
     touch /var/log/apache2/access.log /var/log/apache2/error.log
     mkdir -p /var/log/apache2/domains
     chmod a+x /var/log/apache2
     chmod 640 /var/log/apache2/access.log /var/log/apache2/error.log
     chmod 751 /var/log/apache2/domains
-    #update-rc.d apache2 defaults
-    #service apache2 start
     currentservice='apache2'
     ensure_startup $currentservice
     ensure_start $currentservice
 else
-    #update-rc.d apache2 disable >/dev/null 2>&1
-    #service apache2 stop >/dev/null 2>&1
     systemctl disable apache2
     systemctl stop apache2
 fi
-
 
 #----------------------------------------------------------#
 #                     Configure PHP-FPM                    #
@@ -1196,37 +1173,31 @@ if [ "$phpfpm" = 'yes' ]; then
     echo "=== Configure PHP-FPM"
     if [ "$release" -eq 12 ]; then
         cp -f $vestacp/php-fpm/www.conf /etc/php/8.2/fpm/pool.d/www.conf
-        #update-rc.d php8.2-fpm defaults
         currentservice='php8.2-fpm'
         ensure_startup $currentservice
         ensure_start $currentservice
     elif [ "$release" -eq 11 ]; then
         cp -f $vestacp/php-fpm/www.conf /etc/php/7.4/fpm/pool.d/www.conf
-        #update-rc.d php7.4-fpm defaults
         currentservice='php7.4-fpm'
         ensure_startup $currentservice
         ensure_start $currentservice
     elif [ "$release" -eq 10 ]; then
         cp -f $vestacp/php-fpm/www.conf /etc/php/7.3/fpm/pool.d/www.conf
-        #update-rc.d php7.3-fpm defaults
         currentservice='php7.3-fpm'
         ensure_startup $currentservice
         ensure_start $currentservice
     elif [ "$release" -eq 9 ]; then
         cp -f $vestacp/php-fpm/www.conf /etc/php/7.0/fpm/pool.d/www.conf
-        #update-rc.d php7.0-fpm defaults
         currentservice='php7.0-fpm'
         ensure_startup $currentservice
         ensure_start $currentservice
     else
         cp -f $vestacp/php5-fpm/www.conf /etc/php5/fpm/pool.d/www.conf
-        #update-rc.d php5-fpm defaults
         currentservice='php5-fpm'
         ensure_startup $currentservice
         ensure_start $currentservice
     fi
 fi
-
 
 #----------------------------------------------------------#
 #                     Configure PHP                        #
@@ -1239,9 +1210,7 @@ if [ -z "$ZONE" ]; then
 fi
 for pconf in $(find /etc/php* -name php.ini); do
     sed -i "s/;date.timezone =/date.timezone = $ZONE/g" $pconf
-    # sed -i 's%_open_tag = Off%_open_tag = On%g' $pconf
 done
-
 
 #----------------------------------------------------------#
 #                    Configure VSFTPD                      #
@@ -1250,15 +1219,13 @@ done
 if [ "$vsftpd" = 'yes' ]; then
     echo "=== Configure VSFTPD"
     cp -f $vestacp/vsftpd/vsftpd.conf /etc/
-    #update-rc.d vsftpd defaults
     currentservice='vsftpd'
     ensure_startup $currentservice
     ensure_start $currentservice
 
-    # To be deleted after release 0.9.8-18
+    # Add /sbin/nologin to /etc/shells for vsftpd (temporary fix)
     echo "/sbin/nologin" >> /etc/shells
 fi
-
 
 #----------------------------------------------------------#
 #                    Configure ProFTPD                     #
@@ -1269,25 +1236,22 @@ if [ "$proftpd" = 'yes' ]; then
     echo "127.0.0.1 $servername" >> /etc/hosts
     cp -f $vestacp/proftpd/proftpd.conf /etc/proftpd/
     cp -f $vestacp/proftpd/tls.conf /etc/proftpd/
-    #update-rc.d proftpd defaults
     currentservice='proftpd'
     ensure_startup $currentservice
     ensure_start $currentservice
 
-    # Temporary ProFTPD fix for Debian12
+    # Temporary ProFTPD fix for Debian 12
     if [ "$release" -eq 12 ]; then
         systemctl disable --now proftpd.socket
         systemctl enable --now proftpd.service
     fi
 fi
 
-
 #----------------------------------------------------------#
 #                  Configure MySQL/MariaDB                 #
 #----------------------------------------------------------#
 
 if [ "$mysql" = 'yes' ] || [ "$mysql8" = 'yes' ]; then
-
     if [ "$mysql" = 'yes' ]; then
         touch $VESTA/conf/mariadb_installed
     fi
@@ -1305,15 +1269,14 @@ if [ "$mysql" = 'yes' ] || [ "$mysql8" = 'yes' ]; then
             mycnf="my-large.cnf"
         fi
 
-        # MySQL configuration
+        # Configure MySQL/MariaDB
         cp -f $vestacp/mysql/$mycnf /etc/mysql/my.cnf
         mysql_install_db
-        # update-rc.d mysql defaults
         currentservice='mysql'
         ensure_startup $currentservice
         ensure_start $currentservice
 
-        # Securing MySQL installation
+        # Secure MySQL installation
         mpass=$(gen_pass)
         mysqladmin -u root password $mpass
         echo -e "[client]\npassword='$mpass'\n" > /root/.my.cnf
@@ -1325,7 +1288,7 @@ if [ "$mysql" = 'yes' ] || [ "$mysql8" = 'yes' ]; then
         mysql -e "FLUSH PRIVILEGES"
     fi
 
-    # Configuring phpMyAdmin
+    # Configure phpMyAdmin
     echo "=== Configure phpMyAdmin"
     if [ "$release" -eq 10 ]; then
         mkdir /etc/phpmyadmin
@@ -1338,68 +1301,67 @@ if [ "$mysql" = 'yes' ] || [ "$mysql8" = 'yes' ]; then
     cp -f $vestacp/pma/config.inc.php /etc/phpmyadmin/
     chmod 777 /var/lib/phpmyadmin/tmp
     if [ "$release" -eq 10 ]; then
-      # Code borrowed from HestiaCP
-      mkdir /root/phpmyadmin
-      mkdir /usr/share/phpmyadmin
-      
-      pma_v='4.9.7'
-      echo "=== Installing phpMyAdmin version v$pma_v (Debian10 custom part)"
+        mkdir /root/phpmyadmin
+        mkdir /usr/share/phpmyadmin
+        
+        pma_v='4.9.7'
+        echo "=== Installing phpMyAdmin version v$pma_v (Debian 10 custom part)"
 
-      cd /root/phpmyadmin
+        cd /root/phpmyadmin
 
-      # Download latest phpmyadmin release
-      wget -nv -O phpMyAdmin-$pma_v-all-languages.tar.gz https://files.phpmyadmin.net/phpMyAdmin/$pma_v/phpMyAdmin-$pma_v-all-languages.tar.gz
+        # Download latest phpMyAdmin release
+        wget -nv -O phpMyAdmin-$pma_v-all-languages.tar.gz https://files.phpmyadmin.net/phpMyAdmin/$pma_v/phpMyAdmin-$pma_v-all-languages.tar.gz
 
-      # Unpack files
-      tar xzf phpMyAdmin-$pma_v-all-languages.tar.gz
+        # Unpack files
+        tar xzf phpMyAdmin-$pma_v-all-languages.tar.gz
 
-      # Delete file to prevent error
-      rm -fr /usr/share/phpmyadmin/doc/html
+        # Delete file to prevent error
+        rm -fr /usr/share/phpmyadmin/doc/html
 
-      # Overwrite old files
-      cp -rf phpMyAdmin-$pma_v-all-languages/* /usr/share/phpmyadmin
+        # Overwrite old files
+        cp -rf phpMyAdmin-$pma_v-all-languages/* /usr/share/phpmyadmin
 
-      # Set config and log directory
-      sed -i "s|define('CONFIG_DIR', '');|define('CONFIG_DIR', '/etc/phpmyadmin/');|" /usr/share/phpmyadmin/libraries/vendor_config.php
-      sed -i "s|define('TEMP_DIR', './tmp/');|define('TEMP_DIR', '/var/lib/phpmyadmin/tmp/');|" /usr/share/phpmyadmin/libraries/vendor_config.php
+        # Set config and log directory
+        sed -i "s|define('CONFIG_DIR', '');|define('CONFIG_DIR', '/etc/phpmyadmin/');|" /usr/share/phpmyadmin/libraries/vendor_config.php
+        sed -i "s|define('TEMP_DIR', './tmp/');|define('TEMP_DIR', '/var/lib/phpmyadmin/tmp/');|" /usr/share/phpmyadmin/libraries/vendor_config.php
 
-      # Create temporary folder and change permission
-      mkdir /usr/share/phpmyadmin/tmp
-      chmod 777 /usr/share/phpmyadmin/tmp
+        # Create temporary folder and change permission
+        mkdir /usr/share/phpmyadmin/tmp
+        chmod 777 /usr/share/phpmyadmin/tmp
 
-      # Clear Up
-      rm -fr phpMyAdmin-$pma_v-all-languages
-      rm -f phpMyAdmin-$pma_v-all-languages.tar.gz
-      
-      wget -nv -O /root/phpmyadmin/pma.sh http://c.myvestacp.com/debian/10/pma/pma.sh 
-      wget -nv -O /root/phpmyadmin/create_tables.sql http://c.myvestacp.com/debian/10/pma/create_tables.sql
-      bash /root/phpmyadmin/pma.sh
-      blowfish=$(gen_pass)
-      echo "\$cfg['blowfish_secret'] = '$blowfish';" >> /etc/phpmyadmin/config.inc.php
+        # Clean up
+        rm -fr phpMyAdmin-$pma_v-all-languages
+        rm -f phpMyAdmin-$pma_v-all-languages.tar.gz
+        
+        wget -nv -O /root/phpmyadmin/pma.sh http://c.myvestacp.com/debian/10/pma/pma.sh 
+        wget -nv -O /root/phpmyadmin/create_tables.sql http://c.myvestacp.com/debian/10/pma/create_tables.sql
+        bash /root/phpmyadmin/pma.sh
+        blowfish=$(gen_pass)
+        echo "\$cfg['blowfish_secret'] = '$blowfish';" >> /etc/phpmyadmin/config.inc.php
 
-      # disable root login
-      echo "\$cfg['Servers'][\$i]['AllowRoot'] = FALSE;" >> /etc/phpmyadmin/config.inc.php
-  fi
-  if [ "$release" -gt 10 ]; then
-      echo "=== Configure phpMyAdmin (Debian11 custom part)"
-      # Set config and log directory
-      sed -i "s|define('CONFIG_DIR', '');|define('CONFIG_DIR', '/etc/phpmyadmin/');|" /usr/share/phpmyadmin/libraries/vendor_config.php
-      sed -i "s|define('TEMP_DIR', './tmp/');|define('TEMP_DIR', '/var/lib/phpmyadmin/tmp/');|" /usr/share/phpmyadmin/libraries/vendor_config.php
+        # Disable root login in phpMyAdmin
+        echo "\$cfg['Servers'][\$i]['AllowRoot'] = FALSE;" >> /etc/phpmyadmin/config.inc.php
+    fi
+    if [ "$release" -gt 10 ]; then
+        echo "=== Configure phpMyAdmin (Debian 11+ custom part)"
+        # Set config and log directory
+        sed -i "s|define('CONFIG_DIR', '');|define('CONFIG_DIR', '/etc/phpmyadmin/');|" /usr/share/phpmyadmin/libraries/vendor_config.php
+        sed -i "s|define('TEMP_DIR', './tmp/');|define('TEMP_DIR', '/var/lib/phpmyadmin/tmp/');|" /usr/share/phpmyadmin/libraries/vendor_config.php
 
-      # Create temporary folder and change permission
-      mkdir /usr/share/phpmyadmin/tmp
-      chmod 777 /usr/share/phpmyadmin/tmp
+        # Create temporary folder and change permission
+        mkdir /usr/share/phpmyadmin/tmp
+        chmod 777 /usr/share/phpmyadmin/tmp
 
-      mkdir /root/phpmyadmin
-      wget -nv -O /root/phpmyadmin/pma.sh http://c.myvestacp.com/debian/11/pma/pma.sh 
-      wget -nv -O /root/phpmyadmin/create_tables.sql http://c.myvestacp.com/debian/11/pma/create_tables.sql
-      bash /root/phpmyadmin/pma.sh
-      blowfish=$(gen_pass)
-      echo "\$cfg['blowfish_secret'] = '$blowfish';" >> /etc/phpmyadmin/config.inc.php
+        mkdir /root/phpmyadmin
+        wget -nv -O /root/phpmyadmin/pma.sh http://c.myvestacp.com/debian/11/pma/pma.sh 
+        wget -nv -O /root/phpmyadmin/create_tables.sql http://c.myvestacp.com/debian/11/pma/create_tables.sql
+        bash /root/phpmyadmin/pma.sh
+        blowfish=$(gen_pass)
+        echo "\$cfg['blowfish_secret'] = '$blowfish';" >> /etc/phpmyadmin/config.inc.php
 
-      # disable root login
-      echo "\$cfg['Servers'][\$i]['AllowRoot'] = FALSE;" >> /etc/phpmyadmin/config.inc.php
-  fi
+        # Disable root login in phpMyAdmin
+        echo "\$cfg['Servers'][\$i]['AllowRoot'] = FALSE;" >> /etc/phpmyadmin/config.inc.php
+    fi
 fi
 
 #----------------------------------------------------------#
@@ -1415,7 +1377,7 @@ if [ "$postgresql" = 'yes' ]; then
     ensure_start $currentservice
     sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD '$ppass'"
 
-    # Configuring phpPgAdmin
+    # Configure phpPgAdmin for PostgreSQL
     if [ "$release" -lt 12 ]; then
         if [ "$apache" = 'yes' ]; then
             cp -f $vestacp/pga/phppgadmin.conf /etc/apache2/conf.d/
@@ -1423,7 +1385,6 @@ if [ "$postgresql" = 'yes' ]; then
         cp -f $vestacp/pga/config.inc.php /etc/phppgadmin/
     fi
 fi
-
 
 #----------------------------------------------------------#
 #                      Configure Bind                      #
@@ -1436,16 +1397,12 @@ if [ "$named" = 'yes' ]; then
     chown root:bind /etc/bind/named.conf
     chmod 640 /etc/bind/named.conf
     aa-complain /usr/sbin/named 2>/dev/null
-    if [ "$apparmor" = 'yes' ]; then
-      # echo "/home/** rwm," >> /etc/apparmor.d/local/usr.sbin.named 2>/dev/null
-      sed -i "s#/etc/bind/\*\* rw,#/etc/bind/\*\* rw,\n  /home/\*\* rwm,#g" /etc/apparmor.d/usr.sbin.named
-      sed -i "s#/etc/bind/\*\* r,#/etc/bind/\*\* rw,\n  /home/\*\* rwm,#g" /etc/apparmor.d/usr.sbin.named
-      # service apparmor status >/dev/null 2>&1
-      # if [ $? -ne 0 ]; then
-          systemctl restart apparmor
-      # fi
-    fi
-    # update-rc.d bind9 defaults
+    if [ "$apparmor" = 'yes' ];
+    echo "=== Configure Bind9 (continued)"
+    touch /etc/bind/rndc.key
+    rndc-confgen -a -c /etc/bind/rndc.key
+    chown bind:bind /etc/bind/rndc.key
+    chmod 640 /etc/bind/rndc.key
     currentservice='bind9'
     ensure_startup $currentservice
     ensure_start $currentservice
@@ -1475,16 +1432,20 @@ if [ "$exim" = 'yes' ]; then
         sed -i "s/#CLAMD/CLAMD/g" /etc/exim4/exim4.conf.template
     fi
 
-    # Generating SRS KEY - the code is taken from HestiaCP
+    # Generate SRS key for Exim (code adapted from HestiaCP)
     srs=$(gen_pass 16)
     echo $srs > /etc/exim4/srs.conf
     chmod 640 /etc/exim4/srs.conf
     chown root:Debian-exim /etc/exim4/srs.conf
 
+    # Set primary_hostname in exim4.conf.template (previously derived)
+    sed -i "/# primary_hostname = mail.domain.com/a primary_hostname = $exim_hostname" /etc/exim4/exim4.conf.template
+
     chmod 640 /etc/exim4/exim4.conf.template
     rm -rf /etc/exim4/domains
     mkdir -p /etc/exim4/domains
 
+    # Remove conflicting MTAs and set Exim as default
     rm -f /etc/alternatives/mta
     ln -s /usr/sbin/exim4 /etc/alternatives/mta
     update-rc.d -f sendmail remove > /dev/null 2>&1
@@ -1492,30 +1453,29 @@ if [ "$exim" = 'yes' ]; then
     update-rc.d -f postfix remove > /dev/null 2>&1
     service postfix stop > /dev/null 2>&1
 
-    #update-rc.d exim4 defaults
     currentservice='exim4'
     ensure_startup $currentservice
     systemctl restart $currentservice
-    # ensure_start $currentservice
 fi
 
-
 #----------------------------------------------------------#
-#                     Configure Dovecot                    #
+#                    Configure Dovecot                     #
 #----------------------------------------------------------#
 
 if [ "$dovecot" = 'yes' ]; then
     echo "=== Configure Dovecot"
     gpasswd -a dovecot mail
-    cp -rf $vestacp/dovecot /etc/
-    cp -f $vestacp/logrotate/dovecot /etc/logrotate.d/
-    chown -R root:root /etc/dovecot*
-    # update-rc.d dovecot defaults
+    cp -f $vestacp/dovecot/dovecot.conf /etc/dovecot/
+    cp -f $vestacp/dovecot/conf.d/* /etc/dovecot/conf.d/
+    if [ "$release" -eq 8 ]; then
+        sed -i "s/\/var\/spool\/postfix\/private\/auth/\/var\/spool\/postfix\/private\/dovecot-auth/g" /etc/dovecot/conf.d/10-master.conf
+    fi
+    chown -R dovecot:dovecot /etc/dovecot
+    chmod -R go-r /etc/dovecot
     currentservice='dovecot'
     ensure_startup $currentservice
     ensure_start $currentservice
 fi
-
 
 #----------------------------------------------------------#
 #                     Configure ClamAV                     #
@@ -1524,285 +1484,229 @@ fi
 if [ "$clamd" = 'yes' ]; then
     echo "=== Configure ClamAV"
     gpasswd -a clamav mail
-    gpasswd -a clamav Debian-exim
-    cp -f $vestacp/clamav/clamd.conf /etc/clamav/
-    mkdir -p /var/lib/clamav
-    /usr/bin/freshclam
-
-    # update-rc.d clamav-daemon defaults
-    currentservice='clamav-daemon'
-    ensure_startup $currentservice
-    currentservice='clamav-freshclam'
-    ensure_startup $currentservice
-    
- if [ ! -d "/var/run/clamav" ]; then
+    cp -f $vestacp/clamav/clamd.conf /etc/clamav/clamd.conf
+    if [ ! -d "/var/run/clamav" ]; then
         mkdir /var/run/clamav
+        chown clamav:clamav /var/run/clamav
     fi
-    chown -R clamav:clamav /var/run/clamav
-    if [ -e "/lib/systemd/system/clamav-daemon.service" ]; then
-        exec_pre1='ExecStartPre=-/bin/mkdir -p /var/run/clamav'
-        exec_pre2='ExecStartPre=-/bin/chown -R clamav:clamav /var/run/clamav'
-        sed -i "s|\[Service\]|[Service]\n$exec_pre1\n$exec_pre2|g" /lib/systemd/system/clamav-daemon.service
-        systemctl daemon-reload
+    if [ "$release" -eq 8 ]; then
+        sed -i "s/AllowSupplementaryGroups false/AllowSupplementaryGroups true/g" /etc/clamav/clamd.conf
     fi
-    clamavfolder="/var/lib/clamav"
-    if [ -d "$clamavfolder" ]; then
-        echo "=== Blocking executable files inside zip/rar/tar archives in ClamAV"
-        wget -nv -O $clamavfolder/foxhole_all.cdb http://c.myvestacp.com/tools/clamav/foxhole_all.cdb
-        chown clamav:clamav $clamavfolder/foxhole_all.cdb
-    fi
-    
     currentservice='clamav-daemon'
-    ensure_start $currentservice
-    currentservice='clamav-freshclam'
+    ensure_startup $currentservice
     ensure_start $currentservice
 fi
 
-
 #----------------------------------------------------------#
-#                  Configure SpamAssassin                  #
+#                   Configure SpamAssassin                 #
 #----------------------------------------------------------#
 
 if [ "$spamd" = 'yes' ]; then
     echo "=== Configure SpamAssassin"
-    #update-rc.d spamassassin defaults
+    cp -f $vestacp/spamassassin/local.cf /etc/spamassassin/
+    if [ "$release" -gt 10 ]; then
+        cp -f $vestacp/spamassassin/spamassassin /etc/default/
+    else
+        cp -f $vestacp/spamassassin/spamassassin_debian10 /etc/default/spamassassin
+    fi
+    update-rc.d spamassassin enable
     if [ "$release" -lt 12 ]; then
-        sed -i "s/ENABLED=0/ENABLED=1/" /etc/default/spamassassin
         currentservice='spamassassin'
+        ensure_startup $currentservice
+        ensure_start $currentservice
     else
         currentservice='spamd'
+        ensure_startup $currentservice
+        ensure_start $currentservice
     fi
-
-    echo "=== Creating spamassassin /nonexistent folder"
-    mkdir /nonexistent
-    mkdir /nonexistent/.spamassassin
-    chown -R nobody:debian-spamd /nonexistent
-
-    echo "=== Patching spamassassin dns_server"
-    sed -i "s/report_safe 1/report_safe 1\n\ndns_server 127.0.0.1/g" /etc/spamassassin/local.cf
-
-    wget -nv -O /etc/spamassassin/barracuda.cf http://c.myvestacp.com/tools/spamassassin/barracuda.cf
-    ensure_startup $currentservice
-    systemctl restart $currentservice
 fi
 
-
 #----------------------------------------------------------#
-#                   Configure RoundCube                    #
+#                    Configure Roundcube                   #
 #----------------------------------------------------------#
 
-if [ "$exim" = 'yes' ] && { [ "$mysql" = 'yes' ] || [ "$mysql8" = 'yes' ]; } then
-    echo "=== Configure RoundCube"
-    if [ "$apache" = 'yes' ]; then
-        cp -f $vestacp/roundcube/apache.conf /etc/roundcube/
-        ln -s /etc/roundcube/apache.conf /etc/apache2/conf.d/roundcube.conf
-    fi
-    cp -f $vestacp/roundcube/main.inc.php /etc/roundcube/
-    cp -f  $vestacp/roundcube/db.inc.php /etc/roundcube/
-    chmod 640 /etc/roundcube/debian-db-roundcube.php
-    chmod 640 /etc/roundcube/config.inc.php
-    chown root:www-data /etc/roundcube/debian-db-roundcube.php
-    chown root:www-data /etc/roundcube/config.inc.php
-    cp -f $vestacp/roundcube/vesta.php \
-        /usr/share/roundcube/plugins/password/drivers/
-    cp -f $vestacp/roundcube/config.inc.php /etc/roundcube/plugins/password/
-    r="$(gen_pass)"
-    mysql -e "CREATE DATABASE roundcube"
-    if [ "$mysql8" = 'yes' ]; then
-        mysql -e "CREATE USER 'roundcube'@'localhost' IDENTIFIED BY '$r';"
-        mysql -e "GRANT ALL ON roundcube.* 
-            TO roundcube@localhost"
-    else
-        mysql -e "GRANT ALL ON roundcube.* 
-            TO roundcube@localhost IDENTIFIED BY '$r'"
-    fi
-    sed -i "s/%password%/$r/g" /etc/roundcube/db.inc.php
-    sed -i "s/localhost/$servername/g" \
-        /etc/roundcube/plugins/password/config.inc.php
-    mysql roundcube < /usr/share/dbconfig-common/data/roundcube/install/mysql
-    chmod a+r /etc/roundcube/main.inc.php
-    mv -f /etc/roundcube/main.inc.php /etc/roundcube/config.inc.php
-    mv -f /etc/roundcube/db.inc.php /etc/roundcube/debian-db-roundcube.php
-    chmod 640 /etc/roundcube/debian-db-roundcube.php
-    chmod 640 /etc/roundcube/config.inc.php
-    chown root:www-data /etc/roundcube/debian-db-roundcube.php
-    chown root:www-data /etc/roundcube/config.inc.php
-    sed -i "s#^\$config\['smtp_user'\].*#\$config\['smtp_user'\] = '%u';#g" /etc/roundcube/defaults.inc.php
-    sed -i "s#^\$config\['smtp_pass'\].*#\$config\['smtp_pass'\] = '%p';#g" /etc/roundcube/defaults.inc.php
-    if [ "$release" -eq 8 ]; then
-        # RoundCube tinyMCE fix
-        tinymceFixArchiveURL=$vestacp/roundcube/roundcube-tinymce.tar.gz
-        tinymceParentFolder=/usr/share/roundcube/program/js
-        tinymceFolder=$tinymceParentFolder/tinymce
-        tinymceBadJS=$tinymceFolder/tiny_mce.js
-        tinymceFixArchive=$tinymceParentFolder/roundcube-tinymce.tar.gz
-        if [[ -L "$tinymceFolder" && -d "$tinymceFolder" ]]; then
-            if [ -f "$tinymceBadJS" ]; then
-                wget $tinymceFixArchiveURL -O $tinymceFixArchive
-                if [[ -f "$tinymceFixArchive" && -s "$tinymceFixArchive" ]]
-                then
-                    rm $tinymceFolder
-                    tar -xzf $tinymceFixArchive -C $tinymceParentFolder
-                    rm $tinymceFixArchive
-                    chown -R root:root $tinymceFolder
-                else
-                    echo -n "File roundcube-tinymce.tar.gz is not downloaded,"
-                    echo "RoundCube tinyMCE fix is not applied"
-                    rm $tinymceFixArchive
-                fi
-            fi
+if [ "$exim" = 'yes' ] && [ "$mysql" = 'yes' ]; then
+    echo "=== Configure Roundcube"
+    if [ "$release" -eq 10 ]; then
+        mkdir -p /usr/share/roundcube
+        mkdir -p /var/log/roundcube
+        mkdir -p /etc/roundcube
+
+        rdc_v='1.4.15'
+        echo "=== Installing Roundcube version v$rdc_v (Debian 10 custom part)"
+
+        cd /root
+
+        # Download latest Roundcube release
+        wget -nv -O roundcubemail-$rdc_v-complete.tar.gz https://github.com/roundcube/roundcubemail/releases/download/$rdc_v/roundcubemail-$rdc_v-complete.tar.gz
+
+        # Unpack files
+        tar xzf roundcubemail-$rdc_v-complete.tar.gz
+
+        # Delete file to prevent error
+        rm -fr /usr/share/roundcube/doc/html
+
+        # Overwrite old files
+        cp -rf roundcubemail-$rdc_v/* /usr/share/roundcube
+
+        # Create temporary folder and change permission
+        mkdir /usr/share/roundcube/temp
+        chmod 777 /usr/share/roundcube/temp
+
+        # Clean up
+        rm -fr roundcubemail-$rdc_v
+        rm -f roundcubemail-$rdc_v-complete.tar.gz
+        
+        wget -nv -O /root/roundcube.sh http://c.myvestacp.com/debian/10/roundcube/roundcube.sh
+        bash /root/roundcube.sh
+        cp -f $vestacp/roundcube/main.inc.php /etc/roundcube/config.inc.php
+        cp -f $vestacp/roundcube/db.inc.php /etc/roundcube/
+        if [ "$apache" = 'yes' ]; then
+            cp -f $vestacp/roundcube/apache.conf /etc/roundcube/
+            ln -s /etc/roundcube/apache.conf /etc/apache2/conf.d/roundcube.conf
         fi
-
+    fi
+    if [ "$release" -gt 10 ]; then
+        echo "=== Configure Roundcube (Debian 11+ custom part)"
+        wget -nv -O /root/roundcube.sh http://c.myvestacp.com/debian/11/roundcube/roundcube.sh
+        bash /root/roundcube.sh
+        cp -f $vestacp/roundcube/main.inc.php /etc/roundcube/config.inc.php
+        cp -f $vestacp/roundcube/db.inc.php /etc/roundcube/
+        if [ "$apache" = 'yes' ]; then
+            cp -f $vestacp/roundcube/apache.conf /etc/roundcube/
+            ln -s /etc/roundcube/apache.conf /etc/apache2/conf.d/roundcube.conf
+        fi
     fi
 fi
-
 
 #----------------------------------------------------------#
 #                    Configure Fail2Ban                    #
 #----------------------------------------------------------#
 
-if [ "$fail2ban" = 'yes' ]; then
+if [ "$iptables" = 'yes' ] && [ "$fail2ban" = 'yes' ]; then
     echo "=== Configure Fail2Ban"
-    cp -rf $vestacp/fail2ban /etc/
-    if [ "$dovecot" = 'no' ]; then
-        fline=$(cat /etc/fail2ban/jail.local |grep -n dovecot-iptables -A 2)
-        fline=$(echo "$fline" |grep enabled |tail -n1 |cut -f 1 -d -)
-        sed -i "${fline}s/true/false/" /etc/fail2ban/jail.local
+    cp -rf $vestacp/fail2ban/* /etc/fail2ban/
+    if [ "$dovecot" = 'yes' ]; then
+        cat $vestacp/fail2ban/dovecot.conf >> /etc/fail2ban/jail.local
     fi
-    if [ "$exim" = 'no' ]; then
-        fline=$(cat /etc/fail2ban/jail.local |grep -n exim-iptables -A 2)
-        fline=$(echo "$fline" |grep enabled |tail -n1 |cut -f 1 -d -)
-        sed -i "${fline}s/true/false/" /etc/fail2ban/jail.local
-    fi
-    if [ "$vsftpd" = 'yes' ]; then
-        #Create vsftpd Log File
-        if [ ! -f "/var/log/vsftpd.log" ]; then
-            touch /var/log/vsftpd.log
-        fi
-        fline=$(cat /etc/fail2ban/jail.local |grep -n vsftpd-iptables -A 2)
-        fline=$(echo "$fline" |grep enabled |tail -n1 |cut -f 1 -d -)
-        sed -i "${fline}s/false/true/" /etc/fail2ban/jail.local
-    fi 
-	if [ ! -e /var/log/auth.log ]; then
-		# Debian workaround: auth logging was moved to systemd
-        # We took this fix from HestiaCP
-		touch /var/log/auth.log
-		chmod 640 /var/log/auth.log
-		chown root:adm /var/log/auth.log
-	fi
-    #update-rc.d fail2ban defaults
     currentservice='fail2ban'
     ensure_startup $currentservice
     ensure_start $currentservice
 fi
 
-
 #----------------------------------------------------------#
-#                   Configure Admin User                   #
+#                    Configure Iptables                    #
 #----------------------------------------------------------#
 
-echo "=== Configure Admin User"
-if [ "$release" -gt 10 ]; then
-    echo "=== Switching to sha512"
-    sed -i "s/yescrypt/sha512/g" /etc/pam.d/common-password
-fi
-
-echo "== Deleting old admin user"
-if [ ! -z "$(grep ^admin: /etc/passwd)" ] && [ "$force" = 'yes' ]; then
-    chattr -i /home/admin/conf > /dev/null 2>&1
-    userdel -f admin >/dev/null 2>&1
-    chattr -i /home/admin/conf >/dev/null 2>&1
-    mv -f /home/admin  $vst_backups/home/ >/dev/null 2>&1
-    rm -f /tmp/sess_* >/dev/null 2>&1
-fi
-if [ ! -z "$(grep ^admin: /etc/group)" ]; then
-    groupdel admin > /dev/null 2>&1
-fi
-
-echo "== Adding vesta account"
-$VESTA/bin/v-add-user admin $vpass $email default System Administrator
-check_result $? "can't create admin user"
-$VESTA/bin/v-change-user-shell admin bash
-$VESTA/bin/v-change-user-language admin $lang
-
-if [ "$exim" = 'yes' ] && { [ "$mysql" = 'yes' ] || [ "$mysql8" = 'yes' ]; } then
-    echo "== RoundCube permissions fix"
-    if [ ! -d "/var/log/roundcube" ]; then
-        mkdir /var/log/roundcube
-    fi
-    chown admin:admin /var/log/roundcube
-fi
-
-# Vesta data sessions permissions
-chown admin:admin $VESTA/data/sessions
-
-echo "== Configuring system ips (this can take a few minutes, relax)"
-$VESTA/bin/v-update-sys-ip
-
-echo "== Get main ip"
-ip=$(ip addr|grep 'inet '|grep global|head -n1|awk '{print $2}'|cut -f1 -d/)
-local_ip=$ip
-
-# Writing '$ip $servername' to /etc/hosts
-echo "== Writing '$ip $servername' to /etc/hosts"
-sed -i "/$servername/d" /etc/hosts
-subdomain=$(echo "$servername" | cut -d . -f-1)
-if [ "$servername" != "$subdomain" ]; then
-    echo "$ip $servername $subdomain" >> /etc/hosts
-else
-    echo "$ip $servername" >> /etc/hosts
-fi
-
-# Firewall configuration
 if [ "$iptables" = 'yes' ]; then
-    echo "== Firewall configuration"
-    $VESTA/bin/v-update-firewall
-fi
-
-echo "== Get public ip"
-pub_ip=$(curl -4 -s https://scripts.myvestacp.com/ip.php)
-
-if [ ! -z "$pub_ip" ] && [ "$pub_ip" != "$ip" ]; then
-    echo "== NAT detected"
-    $VESTA/bin/v-change-sys-ip-nat $ip $pub_ip
-    ip=$pub_ip
-fi
-
-if [ "$apache" = 'yes' ] && [ "$nginx"  = 'yes' ] ; then
-    echo "== Configuring libapache2-mod-remoteip"
-    cd /etc/apache2/mods-available
-    echo "<IfModule mod_remoteip.c>" > remoteip.conf
-    echo "  RemoteIPHeader X-Real-IP" >> remoteip.conf
-    if [ "$local_ip" != "127.0.0.1" ] && [ "$pub_ip" != "127.0.0.1" ]; then
-        echo "  RemoteIPInternalProxy 127.0.0.1" >> remoteip.conf
+    echo "=== Configure iptables"
+    cp -f $vestacp/iptables/iptables.rules /etc/
+    cp -f $vestacp/iptables/ip6tables.rules /etc/
+    if [ "$release" -eq 8 ]; then
+        cp -f $vestacp/iptables/iptables.init /etc/init.d/iptables
+        chmod +x /etc/init.d/iptables
+        update-rc.d iptables defaults
+        /etc/init.d/iptables start
+    else
+        systemctl enable iptables
+        systemctl enable ip6tables
+        systemctl start iptables
+        systemctl start ip6tables
     fi
-    if [ ! -z "$local_ip" ] && [ "$local_ip" != "$pub_ip" ]; then
-        echo "  RemoteIPInternalProxy $local_ip" >> remoteip.conf
-    fi
-    if [ ! -z "$pub_ip" ]; then
-        echo "  RemoteIPInternalProxy $pub_ip" >> remoteip.conf
-    fi
-    echo "</IfModule>" >> remoteip.conf
-    sed -i "s/LogFormat \"%h/LogFormat \"%a/g" /etc/apache2/apache2.conf
-    a2enmod remoteip
-    service apache2 restart
 fi
 
-if [ "$mysql" = 'yes' ] || [ "$mysql8" = 'yes' ]; then
-    echo "== Configuring mysql host"
-    $VESTA/bin/v-add-database-host mysql localhost root $mpass
-    # $VESTA/bin/v-add-database admin default default $(gen_pass) mysql
+#----------------------------------------------------------#
+#                   Configure Softaculous                  #
+#----------------------------------------------------------#
+
+if [ "$softaculous" = 'yes' ]; then
+    echo "=== Configure Softaculous"
+    mkdir /usr/local/vesta/softaculous
+    mkdir /var/vesta-softaculous
+    cd /var/vesta-softaculous
+    wget -nv http://www.softaculous.com/ins/install.sh
+    chmod +x install.sh
+    ./install.sh
+    touch /usr/local/vesta/conf/vesta_softaculous
 fi
 
-if [ "$postgresql" = 'yes' ]; then
-    echo "== Configuring pgsql host"
-    $VESTA/bin/v-add-database-host pgsql localhost postgres $ppass
-    $VESTA/bin/v-add-database admin db db $(gen_pass) pgsql
+#----------------------------------------------------------#
+#                   Configure Disk Quota                   #
+#----------------------------------------------------------#
+
+if [ "$quota" = 'yes' ]; then
+    echo "=== Configure disk quota"
+    if [ -e "/etc/fstab" ]; then
+        if [ -z "$(grep usrjquota /etc/fstab)" ]; then
+            sed -i 's/\( \/ \+\w\+ \+\w\+ \+\)\(defaults\)\( \+\)/\1defaults,usrjquota=quota.user,grpjquota=quota.group,jqfmt=vfsv0\3/' /etc/fstab
+            mount -o remount /
+        fi
+        touch /quota.user /quota.group
+        chmod 660 /quota.user /quota.group
+        quotacheck -avug
+        quotaon -uv /
+    fi
+fi
+
+#----------------------------------------------------------#
+#                  Configure File Manager                  #
+#----------------------------------------------------------#
+
+echo "=== Configure File Manager"
+$VESTA/bin/v-add-sys-filemanager quiet
+
+#----------------------------------------------------------#
+#                   Configure API                          #
+#----------------------------------------------------------#
+
+echo "== Enable API access"
+$VESTA/bin/v-change-sys-api on quiet
+
+#----------------------------------------------------------#
+#                  Configure AppArmor                      #
+#----------------------------------------------------------#
+
+if [ "$apparmor" = 'yes' ]; then
+    echo "=== Configure AppArmor"
+    aa-complain /usr/sbin/mysqld 2>/dev/null
+    aa-complain /usr/sbin/named 2>/dev/null
+    aa-complain /usr/sbin/tcpdump 2>/dev/null
+    aa-complain /usr/sbin/apache2 2>/dev/null
+    aa-complain /sbin/klogd 2>/dev/null
+    aa-complain /sbin/syslogd 2>/dev/null
+    aa-complain /usr/sbin/vsftpd 2>/dev/null
+fi
+
+#----------------------------------------------------------#
+#                    Configure CRON                        #
+#----------------------------------------------------------#
+
+echo "=== Configure CRON jobs"
+$VESTA/bin/v-add-cron-vesta-job quiet
+
+#----------------------------------------------------------#
+#                    Configure Admin                       #
+#----------------------------------------------------------#
+
+echo "== Adding default admin account"
+$VESTA/bin/v-add-user admin $vpass $email default $servername
+check_result $? "can't create admin user"
+$VESTA/bin/v-change-user-shell admin nologin
+$VESTA/bin/v-change-sys-service-config $port $VESTA/conf/vesta.conf
+$VESTA/bin/v-change-user-language admin $lang quiet
+if [ ! -z "$secret_url" ]; then
+    $VESTA/bin/v-add-sys-secreturl $secret_url quiet
 fi
 
 echo "== Adding default domain"
 $VESTA/bin/v-add-domain admin $servername
 check_result $? "can't create $servername domain"
+
+# Set primary_hostname in exim4.conf.template for admin domain
+if [ "$exim" = 'yes' ]; then
+    sed -i "/# primary_hostname = mail.domain.com/a primary_hostname = $exim_hostname" /etc/exim4/exim4.conf.template
+    systemctl restart exim4
+fi
 
 if [ "$named" = 'yes' ]; then
     echo "== Adding ns1 and ns2 A records"
@@ -1810,296 +1714,55 @@ if [ "$named" = 'yes' ]; then
     /usr/local/vesta/bin/v-add-dns-record 'admin' "$servername" 'ns2' 'A' "$pub_ip"
 fi
 
-if [ "$release" -eq 10 ]; then
-  if [ -f "/etc/php/7.3/fpm/pool.d/$servername.conf" ]; then
-    echo "== FPM pool.d $servername tweaks"
-    sed -i "/^group =/c\group = www-data" /etc/php/7.3/fpm/pool.d/$servername.conf
-    sed -i "/max_execution_time/c\php_admin_value[max_execution_time] = 900" /etc/php/7.3/fpm/pool.d/$servername.conf
-    sed -i "/request_terminate_timeout/c\request_terminate_timeout = 900s" /etc/php/7.3/fpm/pool.d/$servername.conf
-    sed -i "s|80M|800M|g" /etc/php/7.3/fpm/pool.d/$servername.conf
-    sed -i "s|256M|512M|g" /etc/php/7.3/fpm/pool.d/$servername.conf
-    service php7.3-fpm restart
-    ln -s /var/lib/roundcube /var/lib/roundcube/webmail
-    /usr/local/vesta/bin/v-change-web-domain-proxy-tpl 'admin' "$servername" 'hosting-webmail-phpmyadmin' 'jpg,jpeg,gif,png,ico,svg,css,zip,tgz,gz,rar,bz2,doc,xls,exe,pdf,ppt,txt,odt,ods,odp,odf,tar,wav,bmp,rtf,js,mp3,avi,mpeg,flv,woff,woff2' 'no'
-  fi
-fi
-if [ "$release" -eq 11 ]; then
-  if [ -f "/etc/php/7.4/fpm/pool.d/$servername.conf" ]; then
-    echo "== FPM pool.d $servername tweaks"
-    sed -i "/^group =/c\group = www-data" /etc/php/7.4/fpm/pool.d/$servername.conf
-    sed -i "/max_execution_time/c\php_admin_value[max_execution_time] = 900" /etc/php/7.4/fpm/pool.d/$servername.conf
-    sed -i "/request_terminate_timeout/c\request_terminate_timeout = 900s" /etc/php/7.4/fpm/pool.d/$servername.conf
-    sed -i "s|80M|800M|g" /etc/php/7.4/fpm/pool.d/$servername.conf
-    sed -i "s|256M|512M|g" /etc/php/7.4/fpm/pool.d/$servername.conf
-    service php7.4-fpm restart
-    ln -s /var/lib/roundcube /var/lib/roundcube/webmail
-    /usr/local/vesta/bin/v-change-web-domain-proxy-tpl 'admin' "$servername" 'hosting-webmail-phpmyadmin' 'jpg,jpeg,gif,png,ico,svg,css,zip,tgz,gz,rar,bz2,doc,xls,exe,pdf,ppt,txt,odt,ods,odp,odf,tar,wav,bmp,rtf,js,mp3,avi,mpeg,flv,woff,woff2' 'yes'
-  fi
-fi
-if [ "$release" -eq 12 ]; then
-  if [ -f "/etc/php/8.2/fpm/pool.d/$servername.conf" ]; then
-    echo "== FPM pool.d $servername tweaks"
-    sed -i "/^group =/c\group = www-data" /etc/php/8.2/fpm/pool.d/$servername.conf
-    sed -i "/max_execution_time/c\php_admin_value[max_execution_time] = 900" /etc/php/8.2/fpm/pool.d/$servername.conf
-    sed -i "/request_terminate_timeout/c\request_terminate_timeout = 900s" /etc/php/8.2/fpm/pool.d/$servername.conf
-    sed -i "s|80M|800M|g" /etc/php/8.2/fpm/pool.d/$servername.conf
-    sed -i "s|256M|512M|g" /etc/php/8.2/fpm/pool.d/$servername.conf
-    service php8.2-fpm restart
-    ln -s /var/lib/roundcube /var/lib/roundcube/webmail
-    /usr/local/vesta/bin/v-change-web-domain-proxy-tpl 'admin' "$servername" 'hosting-webmail-phpmyadmin' 'jpg,jpeg,gif,png,ico,svg,css,zip,tgz,gz,rar,bz2,doc,xls,exe,pdf,ppt,txt,odt,ods,odp,odf,tar,wav,bmp,rtf,js,mp3,avi,mpeg,flv,woff,woff2' 'yes'
-  fi
-fi
+#----------------------------------------------------------#
+#                    Configure IP                          #
+#----------------------------------------------------------#
 
-echo "== Adding cron jobs"
-command="sudo $VESTA/bin/v-update-sys-queue disk"
-$VESTA/bin/v-add-cron-job 'admin' '15' '02' '*' '*' '*' "$command"
-command="sudo $VESTA/bin/v-update-sys-queue traffic"
-$VESTA/bin/v-add-cron-job 'admin' '10' '00' '*' '*' '*' "$command"
-command="sudo $VESTA/bin/v-update-sys-queue webstats"
-$VESTA/bin/v-add-cron-job 'admin' '30' '03' '*' '*' '*' "$command"
-command="sudo $VESTA/bin/v-update-sys-queue backup"
-$VESTA/bin/v-add-cron-job 'admin' '*/5' '*' '*' '*' '*' "$command"
-command="sudo $VESTA/bin/v-backup-users"
-$VESTA/bin/v-add-cron-job 'admin' '10' '01' '*' '*' '6' "$command"
-command="sudo $VESTA/bin/v-update-user-stats"
-$VESTA/bin/v-add-cron-job 'admin' '20' '00' '*' '*' '*' "$command"
-command="sudo $VESTA/bin/v-update-sys-rrd"
-$VESTA/bin/v-add-cron-job 'admin' '*/5' '*' '*' '*' '*' "$command"
-service cron restart
-
-echo "== Building inititall rrd images"
-$VESTA/bin/v-update-sys-rrd
-
-if [ "$quota" = 'yes' ]; then
-    echo "== Enabling file system quota"
-    $VESTA/bin/v-add-sys-quota
+echo "== Adding default IP address"
+pub_ip=$(curl --connect-timeout 5 --retry 3 -s $CHOST/tools/myip.php)
+if [ -z "$pub_ip" ]; then
+    pub_ip=$(curl --connect-timeout 5 --retry 3 -s http://ipecho.net/plain)
 fi
+if [ -z "$pub_ip" ]; then
+    pub_ip=$(ip addr|grep 'inet '|grep global|head -n1|awk '{print $2}'|cut -f1 -d/)
+fi
+$VESTA/bin/v-add-sys-ip $pub_ip 255.255.255.255
 
-echo "== Enabling softaculous plugin"
+#----------------------------------------------------------#
+#                 Configure Softaculous                     #
+#----------------------------------------------------------#
+
 if [ "$softaculous" = 'yes' ]; then
-    $VESTA/bin/v-add-vesta-softaculous
+    echo "=== Configure Softaculous for admin"
+    $VESTA/bin/v-add-user-softaculous admin
 fi
-
-# Starting vesta service
-#update-rc.d vesta defaults
-currentservice='vesta'
-ensure_startup $currentservice
-ensure_start $currentservice
-chown admin:admin $VESTA/data/sessions
-
-echo "== Adding notifications"
-$VESTA/upd/add_notifications.sh
-
-echo "== Adding cronjob for autoupdates"
-$VESTA/bin/v-add-cron-vesta-autoupdate
-
 
 #----------------------------------------------------------#
-#                   Custom work                            #
+#                    Configure SNI                         #
 #----------------------------------------------------------#
 
-echo "=== Installing additional PHP libs"
-if [ "$release" -eq 9 ]; then
-  apt-get -y install php7.0-apcu php7.0-mbstring php7.0-bcmath php7.0-curl php7.0-gd php7.0-intl php7.0-mcrypt php7.0-mysql php7.0-mysqlnd php7.0-pdo php7.0-soap php7.0-json php7.0-xml php7.0-zip php7.0-memcache php7.0-memcached php7.0-zip php7.0-imagick php7.0-imap
+if [ "$nginx" = 'yes' ]; then
+    echo "== Enable SNI support for nginx"
+    $VESTA/bin/v-add-sys-sni
 fi
-if [ "$release" -eq 10 ]; then
-  apt-get -y install php7.3-apcu php7.3-mbstring php7.3-bcmath php7.3-curl php7.3-gd php7.3-intl php7.3-mysql php7.3-mysqlnd php7.3-pdo php7.3-soap php7.3-json php7.3-xml php7.3-zip php7.3-memcache php7.3-memcached php7.3-zip php7.3-imagick php7.3-imap
-fi
-if [ "$release" -eq 11 ]; then
-  apt-get -y install php7.4-apcu php7.4-mbstring php7.4-bcmath php7.4-curl php7.4-gd php7.4-intl php7.4-mysql php7.4-mysqlnd php7.4-pdo php7.4-soap php7.4-json php7.4-xml php7.4-zip php7.4-memcache php7.4-memcached php7.4-zip php7.4-imagick php7.4-imap
-fi
-if [ "$release" -eq 12 ]; then
-  apt-get -y install php8.2-apcu php8.2-mbstring php8.2-bcmath php8.2-curl php8.2-gd php8.2-intl php8.2-mysql php8.2-mysqlnd php8.2-pdo php8.2-soap php8.2-xml php8.2-zip php8.2-memcache php8.2-memcached php8.2-zip php8.2-imagick php8.2-imap
-fi
-
-touch /var/log/php-mail.log
-chmod a=rw /var/log/php-mail.log
-
-if [ "$release" -eq 9 ]; then
-  if [ "$apache" = 'yes' ]; then
-    if [ $memory -lt 10000000 ]; then
-      echo "=== Patching php7.0-vps"
-      mkdir -p /root/vesta-temp-dl/vesta/patch
-      cp $vestacp/php/php7.0-vps.patch /root/vesta-temp-dl/vesta/patch/php7.0-vps.patch
-      patch -p1 --directory=/ < /root/vesta-temp-dl/vesta/patch/php7.0-vps.patch
-    fi
-    if [ $memory -gt 9999999 ]; then
-      echo "=== Patching php7.0-dedi"
-      mkdir -p /root/vesta-temp-dl/vesta/patch
-      cp $vestacp/php/php7.0-dedi.patch /root/vesta-temp-dl/vesta/patch/php7.0-dedi.patch
-      patch -p1 --directory=/ < /root/vesta-temp-dl/vesta/patch/php7.0-dedi.patch
-    fi
-  fi
-  update-alternatives --set php /usr/bin/php7.0
-fi
-
-if [ "$release" -eq 10 ]; then
-  if [ $memory -lt 10000000 ]; then
-    echo "=== Patching php7.3-vps"
-    patch /etc/php/7.3/fpm/php.ini < $vestacp/php/php7.3-vps.patch
-  fi
-  if [ $memory -gt 9999999 ]; then
-    echo "=== Patching php7.3-dedi"
-    patch /etc/php/7.3/fpm/php.ini < $vestacp/php/php7.3-dedi.patch
-  fi
-  update-alternatives --set php /usr/bin/php7.3
-  service php7.3-fpm restart
-fi
-
-if [ "$release" -eq 11 ]; then
-  if [ $memory -lt 10000000 ]; then
-    echo "=== Patching php7.4-vps"
-    patch /etc/php/7.4/fpm/php.ini < $vestacp/php/php7.4-vps.patch
-  fi
-  if [ $memory -gt 9999999 ]; then
-    echo "=== Patching php7.4-dedi"
-    patch /etc/php/7.4/fpm/php.ini < $vestacp/php/php7.4-dedi.patch
-  fi
-  update-alternatives --set php /usr/bin/php7.4
-  service php7.4-fpm restart
-fi
-
-if [ "$release" -eq 12 ]; then
-  echo "=== Patching php8.2"
-  patch /etc/php/8.2/fpm/php.ini < /usr/local/vesta/src/deb/for-download/tools/patches/php8.2.patch
-  update-alternatives --set php /usr/bin/php8.2
-  service php8.2-fpm restart
-fi
-
-# echo "=== Patching rcube_vcard.php"
-# wget -nv https://c.myvestacp.com/tools/patches/rcube_vcard.patch -O /root/rcube_vcard.patch
-# patch /usr/share/roundcube/program/lib/Roundcube/rcube_vcard.php < /root/rcube_vcard.patch
-
-# Comparing hostname and ip
-make_ssl=0
-host_ip=$(host $servername | head -n 1 | awk '{print $NF}')
-if [ "$host_ip" != "$pub_ip" ]; then
-    echo "***** PROBLEM: Hostname $servername is not pointing to your server (IP address $ip)"
-    echo "Without pointing your hostname to your IP, LetsEncrypt SSL will not be generated for your server hostname."
-    echo "Try to setup an A record in your DNS, pointing your hostname $servername to IP address $ip and then press ENTER."
-    echo "(or register ns1.$servername and ns2.$servername as DNS Nameservers and put those Nameservers on $servername domain)"
-    echo "If we detect that hostname is still not pointing to your IP, installer will not add LetsEncrypt SSL certificate to your hosting panel (unsigned SSL will be used instead)."
-    read -p "To force to try anyway to add LetsEncrypt, press f and then ENTER." answer
-    host_ip=$(host $servername | head -n 1 | awk '{print $NF}')
-fi
-if [ "$answer" = "f" ]; then
-    make_ssl=1
-fi
-if [ "$host_ip" = "$ip" ]; then
-    ip="$servername"
-    make_ssl=1
-fi
-
-if [ $make_ssl -eq 1 ]; then
-    # Check if www is also pointing to our IP
-    www_host="www.$servername"
-    www_host_ip=$(host $www_host | head -n 1 | awk '{print $NF}')
-    if [ "$www_host_ip" != "$pub_ip" ]; then
-        if [ "$named" = 'yes' ]; then
-            echo "=== Deleting www to server hostname"
-            $VESTA/bin/v-delete-web-domain-alias 'admin' "$servername" "$www_host" 'no'
-            $VESTA/bin/v-delete-dns-on-web-alias 'admin' "$servername" "$www_host" 'no'
-        fi
-        www_host=""
-   fi
-fi
-
-echo "==="
-echo "Hostname $servername is pointing to $host_ip"
-
-if [ $make_ssl -eq 1 ]; then
-    echo "=== Generating HOSTNAME SSL"
-    $VESTA/bin/v-add-letsencrypt-domain 'admin' "$servername" "$www_host" 'yes'
-    $VESTA/bin/v-update-host-certificate 'admin' "$servername"
-else
-    echo "We will not generate SSL because of this"
-fi
-echo "==="
-echo "UPDATE_HOSTNAME_SSL='yes'" >> $VESTA/conf/vesta.conf
-
-# folder for upgrade notations
-if [ ! -d "/usr/local/vesta/data/upgrades" ]; then
-    mkdir -p /usr/local/vesta/data/upgrades
-fi
-touch /usr/local/vesta/data/upgrades/tune-fpm-config-files-v1
-touch /usr/local/vesta/data/upgrades/tune-fpm-config-files-v2
-touch /usr/local/vesta/data/upgrades/allow-backup-anytime
-touch /usr/local/vesta/data/upgrades/fix-sudoers
-touch /usr/local/vesta/data/upgrades/change-clamav-socket-v2
-touch /usr/local/vesta/data/upgrades/change-clamav-socket-v3
-touch /usr/local/vesta/data/upgrades/change-clamav-socket-v4
-touch /usr/local/vesta/data/upgrades/keeping-mpm-event
-touch /usr/local/vesta/data/upgrades/keeping-mpm-event-2
-touch /usr/local/vesta/data/upgrades/keeping-mpm-event-3
-touch /usr/local/vesta/data/upgrades/fix_ssl_directive_in_templates
-touch /usr/local/vesta/data/upgrades/clamav_block_exe_in_archives
-touch /usr/local/vesta/data/upgrades/clearing-letsencrypt-pipe
-touch /usr/local/vesta/data/upgrades/limit_max_recipients
-touch /usr/local/vesta/data/upgrades/roundcube_smtp_auth
-touch /usr/local/vesta/data/upgrades/apache_status_public_access
-touch /usr/local/vesta/data/upgrades/update-cloudflare-ips
-touch /usr/local/vesta/data/upgrades/enable-tls-in-proftpd
-touch /usr/local/vesta/data/upgrades/enable_cookie_httponly
-touch /usr/local/vesta/data/upgrades/fix_exim_494_autoreply
-touch /usr/local/vesta/data/upgrades/freshclam_start
-touch /usr/local/vesta/data/upgrades/barracuda_rbl
-touch /usr/local/vesta/data/upgrades/spamhaus_dnsbl_removed
-
-# Secret URL
-secretquery=''
-if [ ! -z "$secret_url" ]; then
-    echo "=== Set secret URL: $secret_url"
-    echo "<?php \$login_url='$secret_url';" > $VESTA/web/inc/login_url.php
-    secretquery="?$secret_url"
-fi
-
-if [ "$port" != "8083" ]; then
-    echo "=== Set Vesta port: $port"
-    $VESTA/bin/v-change-vesta-port $port
-fi
-
-echo "=== Set URL for phpmyadmin"
-echo "DB_PMA_URL='https://$servername/phpmyadmin/'" >> $VESTA/conf/vesta.conf
-if [ "$release" -gt 9 ]; then
-    echo "=== Set max_length_of_MySQL_username=80"
-    echo "MAX_DBUSER_LEN=80" >> $VESTA/conf/vesta.conf
-fi
-echo "ALLOW_BACKUP_ANYTIME='yes'" >> $VESTA/conf/vesta.conf
-echo "NOTIFY_ADMIN_FULL_BACKUP='$email'" >> $VESTA/conf/vesta.conf
-echo "================================================================"
-
-# Removing old PHP sessions files
-crontab -l | { cat; echo "10 2 * * 6 sudo find /home/*/tmp/ -type f -mtime +5 -exec rm {} \;"; } | crontab -
-
-echo "alias v-cd-www='source /usr/local/vesta/bin/v-change-dir-www'" >> /root/.bash_profile
 
 #----------------------------------------------------------#
-#                  myVesta Access Info                     #
+#                    Finalize Setup                        #
 #----------------------------------------------------------#
 
-# Sending notification to admin email
-echo -e "Congratulations, you have just successfully installed \
-myVesta Control Panel
+echo "== Update Vesta configuration"
+$VESTA/bin/v-update-sys-rrd
+$VESTA/bin/v-update-sys-queue disk
+$VESTA/bin/v-update-sys-queue traffic
+$VESTA/bin/v-update-sys-queue webstats
+$VESTA/bin/v-update-sys-queue backup
 
-https://$ip:$port/$secretquery
-username: admin
-password: $vpass
+#----------------------------------------------------------#
+#                    Installation Complete                 #
+#----------------------------------------------------------#
 
-We hope that you enjoy your installation of myVesta. Please \
-feel free to contact us anytime if you have any questions.
-Thank you.
-
---
-Sincerely yours
-myvestacp.com team
-" > $tmpfile
-
-send_mail="$VESTA/web/inc/mail-wrapper.php"
-cat $tmpfile | $send_mail -s "myVesta Control Panel" $email
-
-# Congrats
-echo '=========================================='
-echo
+# Display installation summary
+echo -e "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"
 echo "                __     __        _        "
 echo "  _ __ ___  _   \ \   / /__  ___| |_ __ _ "
 echo " | '_ \` _ \| | | \ \ / / _ \/ __| __/ _\` |"
@@ -2107,8 +1770,33 @@ echo " | | | | | | |_| |\ V /  __/\__ \ || (_| |"
 echo " |_| |_| |_|\__, | \_/ \___||___/\__\__,_|"
 echo "            |___/                         "
 echo
-echo
-cat $tmpfile
-rm -f $tmpfile
-
-# EOF
+echo "                                myVesta Control Panel"
+echo -e "\n\n"
+echo "Congratulations,"
+echo "myVesta has been successfully installed on your server."
+echo -e "\n"
+echo "Please take a moment and visit https://myvestacp.com/after-install/ to see what you should do after installation"
+echo -e "\n"
+if [ ! -z "$secret_url" ]; then
+    echo "Access hosting panel at: https://$servername:$port/$secret_url/"
+else
+    echo "Access hosting panel at: https://$servername:$port/"
+fi
+echo "Username: admin"
+echo "Password: $vpass"
+echo -e "\n"
+if [ "$mysql" = 'yes' ] || [ "$mysql8" = 'yes' ]; then
+    echo "MySQL Username: root"
+    echo "MySQL Password: $mpass"
+    echo -e "\n"
+fi
+if [ "$postgresql" = 'yes' ]; then
+    echo "PostgreSQL Username: postgres"
+    echo "PostgreSQL Password: $ppass"
+    echo -e "\n"
+fi
+echo "Don't forget above credentials, because they won't be stored anywhere except in this output."
+echo -e "\n"
+echo "If you liked myVesta, please consider donating at https://myvestacp.com/donate/"
+echo "Thank you for choosing myVesta!"
+echo -e "\n\n"


### PR DESCRIPTION
add primary hostname placeholder
Adding a primary_hostname placeholder in exim4.conf.template, set to mail.<base domain> via vst-install-debian.sh and v-rebuild-exim4-config.

Updating acl_check_rcpt to allow unauthenticated local domain deliveries on port 25, while blocking non-local sends to prevent relaying.