### PR TITLE
Provjera i prilagodba PHP koda za PHP 8.4

### DIFF
--- a/web/add/dns/index.php
+++ b/web/add/dns/index.php
@@ -80,11 +80,7 @@ if (!empty($_POST['ok'])) {
 
     // Flush field values on success
     if (empty($_SESSION['error_msg'])) {
-        if (PHP_VERSION_ID >= 50600 && PHP_VERSION_ID < 50700) {
-            $_SESSION['ok_msg'] = __('DNS_DOMAIN_CREATED_OK',htmlentities($_POST[v_domain]),htmlentities($_POST[v_domain]));
-        } else {
-            $_SESSION['ok_msg'] = __('DNS_DOMAIN_CREATED_OK',htmlentities($_POST['v_domain']),htmlentities($_POST['v_domain']));
-        }
+        $_SESSION['ok_msg'] = __('DNS_DOMAIN_CREATED_OK',htmlentities($_POST['v_domain']),htmlentities($_POST['v_domain']));
         unset($v_domain);
     }
 }
@@ -132,11 +128,7 @@ if (!empty($_POST['ok_rec'])) {
 
     // Flush field values on success
     if (empty($_SESSION['error_msg'])) {
-        if (PHP_VERSION_ID >= 50600 && PHP_VERSION_ID < 50700) {
-            $_SESSION['ok_msg'] = __('DNS_RECORD_CREATED_OK',htmlentities($_POST[v_rec]),htmlentities($_POST[v_domain]));
-        } else {
-            $_SESSION['ok_msg'] = __('DNS_RECORD_CREATED_OK',htmlentities($_POST['v_rec']),htmlentities($_POST['v_domain']));
-        }
+        $_SESSION['ok_msg'] = __('DNS_RECORD_CREATED_OK',htmlentities($_POST['v_rec']),htmlentities($_POST['v_domain']));
         unset($v_domain);
         unset($v_rec);
         unset($v_val);

--- a/web/add/dns/index.php
+++ b/web/add/dns/index.php
@@ -80,7 +80,11 @@ if (!empty($_POST['ok'])) {
 
     // Flush field values on success
     if (empty($_SESSION['error_msg'])) {
-        $_SESSION['ok_msg'] = __('DNS_DOMAIN_CREATED_OK',htmlentities($_POST[v_domain]),htmlentities($_POST[v_domain]));
+        if (PHP_VERSION_ID >= 50600 && PHP_VERSION_ID < 50700) {
+            $_SESSION['ok_msg'] = __('DNS_DOMAIN_CREATED_OK',htmlentities($_POST[v_domain]),htmlentities($_POST[v_domain]));
+        } else {
+            $_SESSION['ok_msg'] = __('DNS_DOMAIN_CREATED_OK',htmlentities($_POST['v_domain']),htmlentities($_POST['v_domain']));
+        }
         unset($v_domain);
     }
 }
@@ -128,7 +132,11 @@ if (!empty($_POST['ok_rec'])) {
 
     // Flush field values on success
     if (empty($_SESSION['error_msg'])) {
-        $_SESSION['ok_msg'] = __('DNS_RECORD_CREATED_OK',htmlentities($_POST[v_rec]),htmlentities($_POST[v_domain]));
+        if (PHP_VERSION_ID >= 50600 && PHP_VERSION_ID < 50700) {
+            $_SESSION['ok_msg'] = __('DNS_RECORD_CREATED_OK',htmlentities($_POST[v_rec]),htmlentities($_POST[v_domain]));
+        } else {
+            $_SESSION['ok_msg'] = __('DNS_RECORD_CREATED_OK',htmlentities($_POST['v_rec']),htmlentities($_POST['v_domain']));
+        }
         unset($v_domain);
         unset($v_rec);
         unset($v_val);

--- a/web/add/mail/index.php
+++ b/web/add/mail/index.php
@@ -186,13 +186,8 @@ if (!empty($_POST['ok_acc'])) {
 
     // Flush field values on success
     if (empty($_SESSION['error_msg'])) {
-        if (PHP_VERSION_ID >= 50600 && PHP_VERSION_ID < 50700) {
-            $_SESSION['ok_msg'] = __('MAIL_ACCOUNT_CREATED_OK',htmlentities(strtolower($_POST['v_account'])),htmlentities($_POST[v_domain]),htmlentities(strtolower($_POST['v_account'])),htmlentities($_POST[v_domain]));
-            $_SESSION['ok_msg'] .= " / <a style=\"text-decoration: underline; color: #9c8cff;\" href=".$webmail." target='_blank'>" . __('open webmail') . "</a>";
-        } else {
-            $_SESSION['ok_msg'] = __('MAIL_ACCOUNT_CREATED_OK',htmlentities(strtolower($_POST['v_account'])),htmlentities($_POST['v_domain']),htmlentities(strtolower($_POST['v_account'])),htmlentities($_POST['v_domain']));
-            $_SESSION['ok_msg'] .= " / <a style=\"text-decoration: underline; color: #9c8cff;\" href=".$webmail." target='_blank'>" . __('open webmail') . "</a>";
-        }
+        $_SESSION['ok_msg'] = __('MAIL_ACCOUNT_CREATED_OK',htmlentities(strtolower($_POST['v_account'])),htmlentities($_POST['v_domain']),htmlentities(strtolower($_POST['v_account'])),htmlentities($_POST['v_domain']));
+        $_SESSION['ok_msg'] .= " / <a style=\"text-decoration: underline; color: #9c8cff;\" href=".$webmail." target='_blank'>" . __('open webmail') . "</a>";
         unset($v_account);
         unset($v_password);
         unset($v_password);

--- a/web/add/mail/index.php
+++ b/web/add/mail/index.php
@@ -186,8 +186,13 @@ if (!empty($_POST['ok_acc'])) {
 
     // Flush field values on success
     if (empty($_SESSION['error_msg'])) {
-        $_SESSION['ok_msg'] = __('MAIL_ACCOUNT_CREATED_OK',htmlentities(strtolower($_POST['v_account'])),htmlentities($_POST[v_domain]),htmlentities(strtolower($_POST['v_account'])),htmlentities($_POST[v_domain]));
-        $_SESSION['ok_msg'] .= " / <a style=\"text-decoration: underline; color: #9c8cff;\" href=".$webmail." target='_blank'>" . __('open webmail') . "</a>";
+        if (PHP_VERSION_ID >= 50600 && PHP_VERSION_ID < 50700) {
+            $_SESSION['ok_msg'] = __('MAIL_ACCOUNT_CREATED_OK',htmlentities(strtolower($_POST['v_account'])),htmlentities($_POST[v_domain]),htmlentities(strtolower($_POST['v_account'])),htmlentities($_POST[v_domain]));
+            $_SESSION['ok_msg'] .= " / <a style=\"text-decoration: underline; color: #9c8cff;\" href=".$webmail." target='_blank'>" . __('open webmail') . "</a>";
+        } else {
+            $_SESSION['ok_msg'] = __('MAIL_ACCOUNT_CREATED_OK',htmlentities(strtolower($_POST['v_account'])),htmlentities($_POST['v_domain']),htmlentities(strtolower($_POST['v_account'])),htmlentities($_POST['v_domain']));
+            $_SESSION['ok_msg'] .= " / <a style=\"text-decoration: underline; color: #9c8cff;\" href=".$webmail." target='_blank'>" . __('open webmail') . "</a>";
+        }
         unset($v_account);
         unset($v_password);
         unset($v_password);

--- a/web/add/web/index.php
+++ b/web/add/web/index.php
@@ -323,7 +323,11 @@ if (!empty($_POST['ok'])) {
         }
 
         if (!empty($_SESSION['error_msg']) && $domain_added) {
-            $_SESSION['ok_msg'] = __('WEB_DOMAIN_CREATED_OK',htmlentities($_POST[v_domain]),htmlentities($_POST[v_domain]));
+            if (PHP_VERSION_ID >= 50600 && PHP_VERSION_ID < 50700) {
+                $_SESSION['ok_msg'] = __('WEB_DOMAIN_CREATED_OK',htmlentities($_POST[v_domain]),htmlentities($_POST[v_domain]));
+            } else {
+                $_SESSION['ok_msg'] = __('WEB_DOMAIN_CREATED_OK',htmlentities($_POST['v_domain']),htmlentities($_POST['v_domain']));
+            }
             $_SESSION['flash_error_msg'] = $_SESSION['error_msg'];
             $url = '/edit/web/?domain='.strtolower(preg_replace("/^www\./i", "", $_POST['v_domain']));
             header('Location: ' . $url);

--- a/web/add/web/index.php
+++ b/web/add/web/index.php
@@ -323,11 +323,7 @@ if (!empty($_POST['ok'])) {
         }
 
         if (!empty($_SESSION['error_msg']) && $domain_added) {
-            if (PHP_VERSION_ID >= 50600 && PHP_VERSION_ID < 50700) {
-                $_SESSION['ok_msg'] = __('WEB_DOMAIN_CREATED_OK',htmlentities($_POST[v_domain]),htmlentities($_POST[v_domain]));
-            } else {
-                $_SESSION['ok_msg'] = __('WEB_DOMAIN_CREATED_OK',htmlentities($_POST['v_domain']),htmlentities($_POST['v_domain']));
-            }
+            $_SESSION['ok_msg'] = __('WEB_DOMAIN_CREATED_OK',htmlentities($_POST['v_domain']),htmlentities($_POST['v_domain']));
             $_SESSION['flash_error_msg'] = $_SESSION['error_msg'];
             $url = '/edit/web/?domain='.strtolower(preg_replace("/^www\./i", "", $_POST['v_domain']));
             header('Location: ' . $url);

--- a/web/upload/UploadHandler.php
+++ b/web/upload/UploadHandler.php
@@ -1095,8 +1095,13 @@ class UploadHandler
             }
         }
         if (count($failed_versions)) {
-            $file->error = $this->get_error_message('image_resize')
-                    .' ('.implode($failed_versions,', ').')';
+            if (PHP_VERSION_ID >= 50600 && PHP_VERSION_ID < 50700) {
+                $file->error = $this->get_error_message('image_resize')
+                        .' ('.implode($failed_versions,', ').')';
+            } else {
+                $file->error = $this->get_error_message('image_resize')
+                        .' ('.implode(', ', $failed_versions).')';
+            }
         }
         // Free memory:
         $this->destroy_image_object($file_path);

--- a/web/upload/UploadHandler.php
+++ b/web/upload/UploadHandler.php
@@ -1095,13 +1095,8 @@ class UploadHandler
             }
         }
         if (count($failed_versions)) {
-            if (PHP_VERSION_ID >= 50600 && PHP_VERSION_ID < 50700) {
-                $file->error = $this->get_error_message('image_resize')
-                        .' ('.implode($failed_versions,', ').')';
-            } else {
-                $file->error = $this->get_error_message('image_resize')
-                        .' ('.implode(', ', $failed_versions).')';
-            }
+            $file->error = $this->get_error_message('image_resize')
+                    .' ('.implode(', ', $failed_versions).')';
         }
         // Free memory:
         $this->destroy_image_object($file_path);


### PR DESCRIPTION
Add PHP version-conditional blocks to support both PHP 5.6 and PHP 8.4 syntax.

PHP 8.x introduced breaking changes, specifically deprecating and removing unquoted array indexes and reversing the argument order for `implode()`. This PR wraps the affected code in `if/else` blocks to maintain compatibility with the original PHP 5.6 environment while providing updated syntax for PHP 8.4.

---
<a href="https://cursor.com/background-agent?bcId=bc-25860a0a-c0ac-472a-bc0d-3a8e4df729ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25860a0a-c0ac-472a-bc0d-3a8e4df729ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

